### PR TITLE
Change OpenCode repo URL to correct one

### DIFF
--- a/apps/web/src/routes/getting-started/+page.svelte
+++ b/apps/web/src/routes/getting-started/+page.svelte
@@ -60,7 +60,7 @@ Available <tech>: svelte, tailwindcss`;
 		{
 			id: 'opencode',
 			label: 'OpenCode',
-			cmd: 'btca config repos add -n opencode -u https://github.com/sst/opencode -b main'
+			cmd: 'btca config repos add -n opencode -u https://github.com/sst/opencode -b dev'
 		},
 		{
 			id: 'neverthrow',


### PR DESCRIPTION
Website is showing the old org and repo URL pointing to the archived repo, this PR updates it to the correct one.