### PR TITLE
Add Windows x64 support

### DIFF
--- a/apps/cli/bin.js
+++ b/apps/cli/bin.js
@@ -12,6 +12,7 @@ const TARGET_MAP = {
   "darwin-x64": "btca-darwin-x64",
   "linux-x64": "btca-linux-x64",
   "linux-arm64": "btca-linux-arm64",
+  "win32-x64": "btca-windows-x64.exe",
 };
 
 const binaryName = TARGET_MAP[PLATFORM_ARCH];

--- a/apps/cli/scripts/build-binaries.ts
+++ b/apps/cli/scripts/build-binaries.ts
@@ -11,6 +11,7 @@ const targets = [
   "bun-darwin-x64",
   "bun-linux-x64",
   "bun-linux-arm64",
+  "bun-windows-x64",
 ] as const;
 
 const outputNames: Record<(typeof targets)[number], string> = {
@@ -18,6 +19,7 @@ const outputNames: Record<(typeof targets)[number], string> = {
   "bun-darwin-x64": "btca-darwin-x64",
   "bun-linux-x64": "btca-linux-x64",
   "bun-linux-arm64": "btca-linux-arm64",
+  "bun-windows-x64": "btca-windows-x64.exe",
 };
 
 const main = Effect.gen(function* () {


### PR DESCRIPTION
Adds Windows x64 support for the btca CLI tool.

## Changes
- Added `bun-windows-x64` build target in `build-binaries.ts`
- Added `win32-x64` platform mapping in `bin.js` 

## Testing
Built and tested the Windows x64 binary successfully:
- `bun run build:artifacts` completes without errors
- `btca-windows-x64.exe` runs correctly on Windows
- Tested with `btca ask -t svelte -q "How do stores work?"` - works as expected

Fixes #10 and #6

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added Windows x64 support by introducing the `bun-windows-x64` build target and corresponding `win32-x64` platform mapping, resolving issues #10 and #6.

**Changes made:**
- Added `bun-windows-x64` to the build targets array in `build-binaries.ts`
- Mapped `bun-windows-x64` to output filename `btca-windows-x64.exe` 
- Added `win32-x64` platform detection to `TARGET_MAP` in `bin.js`
- Binary naming follows Windows conventions with `.exe` extension

**Impact:**
The PR enables Windows users to install and run the `btca` CLI tool without encountering "Unsupported platform" errors. The implementation is consistent with existing platform support patterns for macOS and Linux.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are minimal, straightforward, and follow the established pattern for other platforms. The implementation adds Windows x64 support by simply extending two configuration arrays with the appropriate build target and platform mapping. The PR has been tested by the author, and the changes are symmetric with existing platform support (darwin-arm64, darwin-x64, linux-x64, linux-arm64).
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/cli/bin.js | 5/5 | Added `win32-x64` platform mapping to `TARGET_MAP`, enabling Windows x64 support in the binary launcher |
| apps/cli/scripts/build-binaries.ts | 5/5 | Added `bun-windows-x64` build target and corresponding output name mapping for Windows binary compilation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant bin.js
    participant Process
    participant Binary
    participant BuildScript as build-binaries.ts

    Note over BuildScript: Build-time (prepublishOnly)
    BuildScript->>BuildScript: Iterate through targets array
    BuildScript->>BuildScript: Add "bun-windows-x64" target
    BuildScript->>BuildScript: Map to "btca-windows-x64.exe"
    BuildScript->>Binary: Compile Windows binary with Bun

    Note over User,Binary: Runtime (User invokes btca)
    User->>bin.js: Execute btca command
    bin.js->>Process: Get platform/arch (win32-x64)
    bin.js->>bin.js: Lookup in TARGET_MAP
    bin.js->>bin.js: Find "btca-windows-x64.exe"
    bin.js->>Binary: Check dist/btca-windows-x64.exe exists
    alt Binary exists
        bin.js->>Binary: spawnSync(binary, args)
        Binary->>User: Execute CLI command
    else Binary not found
        bin.js->>User: Error: Prebuilt binary not found
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->