### PR TITLE
Fixed runed link

### DIFF
--- a/apps/web/src/routes/getting-started/+page.svelte
+++ b/apps/web/src/routes/getting-started/+page.svelte
@@ -70,7 +70,7 @@ Available <tech>: svelte, tailwindcss`;
 		{
 			id: 'runed',
 			label: 'Runed',
-			cmd: 'btca config repos add -n runed -u https://github.com/svelte-plugins/runed -b main'
+			cmd: 'btca config repos add -n runed -u https://github.com/svecosystem/runed -b main'
 		}
 	] as const;
 


### PR DESCRIPTION
fix #15

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed broken GitHub URL for the runed repository from `svelte-plugins/runed` to `svecosystem/runed`.

- The old URL (`https://github.com/svelte-plugins/runed`) returns 404
- The new URL (`https://github.com/svecosystem/runed`) is valid and accessible
- This corrects the command shown on the getting-started page for adding runed to btca config

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is a simple URL correction that fixes a broken link. The old URL returns 404 and the new URL is valid. No logic, functionality, or code structure is affected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/routes/getting-started/+page.svelte | 5/5 | Updated runed repository URL from `svelte-plugins/runed` to `svecosystem/runed` to fix broken link |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GettingStartedPage
    participant GitHub
    
    User->>GettingStartedPage: Clicks "Runed" tech card
    GettingStartedPage->>User: Copies command to clipboard
    Note over User: btca config repos add -n runed<br/>-u https://github.com/svecosystem/runed -b main
    User->>GitHub: Executes command (btca uses URL)
    GitHub->>User: Successfully clones repository
    Note over User,GitHub: Previously: svelte-plugins/runed (404)<br/>Now: svecosystem/runed (200)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->