### PR TITLE
fix: Windows path expansion for home directory

### DIFF
--- a/apps/cli/src/lib/utils/files.ts
+++ b/apps/cli/src/lib/utils/files.ts
@@ -1,49 +1,49 @@
-import { FileSystem, Path } from "@effect/platform";
-import { Effect } from "effect";
-import { ConfigError } from "../errors.ts";
+import { FileSystem, Path } from '@effect/platform';
+import { Effect } from 'effect';
+import { ConfigError } from '../errors.ts';
 
 export const expandHome = (filePath: string): Effect.Effect<string, never, Path.Path> =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    if (filePath.startsWith("~/")) {
-      const homeDir = Bun.env.HOME ?? Bun.env.USERPROFILE ?? "";
-      return path.join(homeDir, filePath.slice(2));
-    }
-    return filePath;
-  });
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		if (filePath.startsWith('~/') || filePath.startsWith('~\\')) {
+			const homeDir = Bun.env.HOME ?? Bun.env.USERPROFILE ?? '';
+			return path.join(homeDir, filePath.slice(2));
+		}
+		return filePath;
+	});
 
 export const directoryExists = (dir: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const exists = yield* fs.exists(dir);
-    if (!exists) return false;
-    const stat = yield* fs.stat(dir);
-    return stat.type === "Directory";
-  }).pipe(
-    Effect.catchAll((error) =>
-      Effect.fail(
-        new ConfigError({
-          message: "Failed to check directory",
-          cause: error,
-        })
-      )
-    )
-  );
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const exists = yield* fs.exists(dir);
+		if (!exists) return false;
+		const stat = yield* fs.stat(dir);
+		return stat.type === 'Directory';
+	}).pipe(
+		Effect.catchAll((error) =>
+			Effect.fail(
+				new ConfigError({
+					message: 'Failed to check directory',
+					cause: error
+				})
+			)
+		)
+	);
 
 export const ensureDirectory = (dir: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const exists = yield* fs.exists(dir);
-    if (!exists) {
-      yield* fs.makeDirectory(dir, { recursive: true });
-    }
-  }).pipe(
-    Effect.catchAll((error) =>
-      Effect.fail(
-        new ConfigError({
-          message: "Failed to create directory",
-          cause: error,
-        })
-      )
-    )
-  );
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const exists = yield* fs.exists(dir);
+		if (!exists) {
+			yield* fs.makeDirectory(dir, { recursive: true });
+		}
+	}).pipe(
+		Effect.catchAll((error) =>
+			Effect.fail(
+				new ConfigError({
+					message: 'Failed to create directory',
+					cause: error
+				})
+			)
+		)
+	);


### PR DESCRIPTION
Summary
- Fixes an issue where `expandHome` did not correctly handle Windows paths starting with `~\`.
- Ensures that paths like `~\.local\share\btca\repos` are correctly expanded to the user's home directory instead of creating a literal `~` folder in the current working directory.
 
Problem
On Windows, paths often use backslashes. The previous implementation only checked for `~/`. When `btca` tried to clone a repo to `~\.local\share...`, the check failed, and the tool treated `~` as a literal folder name in the current directory.
 
Fix
Updated `apps/cli/src/lib/utils/files.ts` to check for both `~/` and `~\` prefixes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed Windows home directory expansion by adding support for `~\` prefix alongside existing `~/` support. The change is minimal and backward-compatible.

- Added `|| filePath.startsWith('~\\')` check on line 8 to handle Windows-style paths
- Formatting changes (tabs, single quotes) applied throughout file

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is a simple, logical addition that handles Windows path separators without breaking existing Unix/Linux functionality. The `.slice(2)` works correctly for both `~/` and `~\`, and `path.join()` handles cross-platform path construction properly
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/cli/src/lib/utils/files.ts | 5/5 | Added Windows backslash support to `expandHome` function - simple, backward-compatible fix |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->