### PR TITLE
now installs with bun

### DIFF
--- a/apps/cli/bin.js
+++ b/apps/cli/bin.js
@@ -1,48 +1,54 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
-import { spawnSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+if (typeof Bun === 'undefined') {
+	console.error('[btca] This CLI requires Bun. Install it: https://bun.sh');
+	console.error('       Then run: bun install -g btca');
+	process.exit(1);
+}
+
+import path from 'node:path';
 
 const PLATFORM_ARCH = `${process.platform}-${process.arch}`;
 
 const TARGET_MAP = {
-  "darwin-arm64": "btca-darwin-arm64",
-  "darwin-x64": "btca-darwin-x64",
-  "linux-x64": "btca-linux-x64",
-  "linux-arm64": "btca-linux-arm64",
-  "win32-x64": "btca-windows-x64.exe",
+	'darwin-arm64': 'btca-darwin-arm64',
+	'darwin-x64': 'btca-darwin-x64',
+	'linux-x64': 'btca-linux-x64',
+	'linux-arm64': 'btca-linux-arm64',
+	'win32-x64': 'btca-windows-x64.exe'
 };
 
 const binaryName = TARGET_MAP[PLATFORM_ARCH];
 
 if (!binaryName) {
-  console.error(
-    `[btca] Unsupported platform: ${PLATFORM_ARCH}. ` +
-      "Please open an issue with your OS/CPU details."
-  );
-  process.exit(1);
+	console.error(
+		`[btca] Unsupported platform: ${PLATFORM_ARCH}. ` +
+			'Please open an issue with your OS/CPU details.'
+	);
+	process.exit(1);
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const binPath = path.join(__dirname, "dist", binaryName);
+const __dirname = path.dirname(Bun.fileURLToPath(import.meta.url));
+const binPath = path.join(__dirname, 'dist', binaryName);
+const binFile = Bun.file(binPath);
 
-if (!fs.existsSync(binPath)) {
-  console.error(
-    `[btca] Prebuilt binary not found for ${PLATFORM_ARCH}. ` +
-      "Try reinstalling, or open an issue if the problem persists."
-  );
-  process.exit(1);
+if (!binFile.exists()) {
+	console.error(
+		`[btca] Prebuilt binary not found for ${PLATFORM_ARCH}. ` +
+			'Try reinstalling, or open an issue if the problem persists.'
+	);
+	process.exit(1);
 }
 
-const result = spawnSync(binPath, process.argv.slice(2), {
-  stdio: "inherit",
+const result = Bun.spawnSync([binPath, ...process.argv.slice(2)], {
+	stdout: 'inherit',
+	stderr: 'inherit',
+	stdin: 'inherit'
 });
 
 if (result.error) {
-  console.error(`[btca] Failed to start binary: ${result.error}`);
-  process.exit(1);
+	console.error(`[btca] Failed to start binary: ${result.error}`);
+	process.exit(1);
 }
 
 process.exit(result.status ?? 1);

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "btca",
 	"author": "Ben Davis",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "CLI tool for asking questions about technologies using OpenCode",
 	"type": "module",
 	"license": "MIT",

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/cli": {
       "name": "btca",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "bin": {
         "btca": "./bin.js",
       },
@@ -861,6 +861,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@btca/shared/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
     "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
@@ -875,6 +877,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "btca/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -882,6 +886,10 @@
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "vite/esbuild": ["esbuild@0.27.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.1", "@esbuild/android-arm": "0.27.1", "@esbuild/android-arm64": "0.27.1", "@esbuild/android-x64": "0.27.1", "@esbuild/darwin-arm64": "0.27.1", "@esbuild/darwin-x64": "0.27.1", "@esbuild/freebsd-arm64": "0.27.1", "@esbuild/freebsd-x64": "0.27.1", "@esbuild/linux-arm": "0.27.1", "@esbuild/linux-arm64": "0.27.1", "@esbuild/linux-ia32": "0.27.1", "@esbuild/linux-loong64": "0.27.1", "@esbuild/linux-mips64el": "0.27.1", "@esbuild/linux-ppc64": "0.27.1", "@esbuild/linux-riscv64": "0.27.1", "@esbuild/linux-s390x": "0.27.1", "@esbuild/linux-x64": "0.27.1", "@esbuild/netbsd-arm64": "0.27.1", "@esbuild/netbsd-x64": "0.27.1", "@esbuild/openbsd-arm64": "0.27.1", "@esbuild/openbsd-x64": "0.27.1", "@esbuild/openharmony-arm64": "0.27.1", "@esbuild/sunos-x64": "0.27.1", "@esbuild/win32-arm64": "0.27.1", "@esbuild/win32-ia32": "0.27.1", "@esbuild/win32-x64": "0.27.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA=="],
+
+    "@btca/shared/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "btca/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA=="],
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Migrated the CLI entry point from Node.js to Bun runtime by changing the shebang, replacing Node APIs with Bun equivalents (`Bun.fileURLToPath`, `Bun.file`, `Bun.spawnSync`), and adding a runtime check for Bun availability.

**Major Issues:**
- **Breaking change**: The shebang change from `#!/usr/bin/env node` to `#!/usr/bin/env bun` breaks installations via `npm install -g btca`. Users won't have `bun` in their PATH, causing immediate "command not found" errors before the runtime check can execute.
- **Potential async bug**: `binFile.exists()` may be asynchronous. If it returns a Promise, the check will always be truthy and won't catch missing binaries.
- **API behavior verification needed**: The spawn API changes need testing to ensure arguments are passed correctly and exit codes match the previous Node.js behavior.

<h3>Confidence Score: 1/5</h3>


- This PR has critical breaking changes that will prevent existing npm users from running the CLI
- The shebang change fundamentally breaks npm-based installations (which the README still promotes), and there's a likely bug in the exists() check that could cause silent failures. These are blocking issues that affect core functionality.
- Pay close attention to `apps/cli/bin.js` - the shebang and exists() check require fixes before this can be safely merged

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/bin.js | Migrated from Node.js to Bun runtime. Critical issue: breaks npm installations as shebang requires Bun in PATH. Also has potential async bug with `exists()` method. |
| apps/cli/package.json | Version bump from 0.5.0 to 0.5.1 for Bun migration release. |
| bun.lock | Lockfile updated with `@types/bun` dependencies for Bun API type support. |

</details>



<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->