### PR TITLE
max instances bumped, temp fix for this issue...

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "btca",
 	"author": "Ben Davis",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "CLI tool for asking questions about technologies using OpenCode",
 	"type": "module",
 	"license": "MIT",

--- a/apps/cli/src/services/oc.ts
+++ b/apps/cli/src/services/oc.ts
@@ -39,7 +39,7 @@ const ocService = Effect.gen(function* () {
 	const getOpencodeInstance = ({ tech }: { tech: string }) =>
 		Effect.gen(function* () {
 			let portOffset = 0;
-			const maxInstances = 5;
+			const maxInstances = 30;
 			const { ocConfig, repoDir } = yield* config.getOpenCodeConfig({ repoName: tech });
 
 			yield* Effect.sync(() => process.chdir(repoDir));


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR bumps the version to 0.5.2 and increases the hard-coded `maxInstances` limit from 5 to 30 in the OpenCode instance creation logic.

**Key changes:**
- Version bump (0.5.1 → 0.5.2)
- `maxInstances` increased from 5 to 30 for port allocation (ports 3420-3449)

**Issues found:**
- Hard-coded value bypasses user configuration: the `maxInstances` value is defined in the config schema and stored in user config files, but this change ignores it by hard-coding 30
- Inconsistency: default config still shows 5, documentation shows 5, but code now uses 30

<h3>Confidence Score: 3/5</h3>


- This PR is moderately safe but has a configuration consistency issue that should be addressed
- The change itself won't break existing functionality (the port allocation logic will work fine with 30 instead of 5), but it introduces a problematic pattern by hard-coding a value that should come from user configuration. This bypasses the configurable `maxInstances` setting defined in the config schema, creating inconsistency between what users can configure and what actually runs.
- apps/cli/src/services/oc.ts needs attention to respect user configuration

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/package.json | Version bumped from 0.5.1 to 0.5.2 |
| apps/cli/src/services/oc.ts | Increased `maxInstances` from 5 to 30 for port allocation, but config default and docs still reference 5 |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->