### PR TITLE
no sync flag added to the cli ask command

### DIFF
--- a/apps/cli/src/services/cli.ts
+++ b/apps/cli/src/services/cli.ts
@@ -20,14 +20,15 @@ const programLayer = Layer.mergeAll(OcService.Default, ConfigService.Default);
 // === Ask Subcommand ===
 const questionOption = Options.text('question').pipe(Options.withAlias('q'));
 const techOption = Options.text('tech').pipe(Options.withAlias('t'));
+const noSyncOption = Options.boolean('no-sync').pipe(Options.withAlias('n'));
 
 const askCommand = Command.make(
 	'ask',
-	{ question: questionOption, tech: techOption },
-	({ question, tech }) =>
+	{ question: questionOption, tech: techOption, noSync: noSyncOption },
+	({ question, tech, noSync }) =>
 		Effect.gen(function* () {
 			const oc = yield* OcService;
-			const eventStream = yield* oc.askQuestion({ tech, question, suppressLogs: false });
+			const eventStream = yield* oc.askQuestion({ tech, question, suppressLogs: false, noSync });
 
 			let currentMessageId: string | null = null;
 

--- a/apps/cli/src/services/oc.ts
+++ b/apps/cli/src/services/oc.ts
@@ -191,11 +191,16 @@ const ocService = Effect.gen(function* () {
 					catch: (err) => new OcError({ message: 'TUI exited with error', cause: err })
 				});
 			}),
-		askQuestion: (args: { question: string; tech: string; suppressLogs: boolean }) =>
+		askQuestion: (args: {
+			question: string;
+			tech: string;
+			suppressLogs: boolean;
+			noSync?: boolean;
+		}) =>
 			Effect.gen(function* () {
 				const { question, tech, suppressLogs } = args;
 
-				yield* config.cloneOrUpdateOneRepoLocally(tech, { suppressLogs });
+				yield* config.cloneOrUpdateOneRepoLocally(tech, { suppressLogs, noSync: args.noSync });
 
 				const { client, server } = yield* getOpencodeInstance({ tech });
 


### PR DESCRIPTION
credit: https://github.com/davis7dotsh/better-context/issues/38

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `--no-sync` (alias `-n`) flag to the `ask` command, allowing users to skip repository synchronization when querying. When enabled, existing repos are used as-is without pulling latest changes, reducing latency for quick queries.

- Added `noSyncOption` boolean flag to CLI `ask` command
- Threaded `noSync` parameter through service layer (`oc.askQuestion` → `config.cloneOrUpdateOneRepoLocally`)
- Modified sync logic to skip `git pull` when `noSync` is true, and skip completion log
- Preserves existing behavior: repos are still cloned if they don't exist locally

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Clean implementation that adds optional functionality without breaking existing features. The `noSync` parameter is optional, defaults to undefined (falsy), and backward compatible with all existing callers. Logic is straightforward and properly threaded through the call chain.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/services/cli.ts | Added `--no-sync` flag to ask command to skip repo sync |
| apps/cli/src/services/config.ts | Updated `cloneOrUpdateOneRepoLocally` to support `noSync` parameter |
| apps/cli/src/services/oc.ts | Threaded `noSync` parameter through `askQuestion` method |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->