### PR TITLE
Disable MCP servers in btca opencode config

### DIFF
--- a/apps/cli/src/services/config.ts
+++ b/apps/cli/src/services/config.ts
@@ -133,6 +133,7 @@ const OPENCODE_CONFIG = (args: {
 	Effect.gen(function* () {
 		return {
 			provider: BTCA_PRESET_MODELS,
+			mcp: {},
 			agent: {
 				build: {
 					disable: true


### PR DESCRIPTION
Adds `mcp: {}` to the opencode config to disable MCP servers.

This ensures the docs agent only searches local repos and doesn't use external MCP tools.