### PR TITLE
scripts, agents, etc.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,27 @@
 # AGENTS.md
 
+## Critical Rules
+
+- **ONLY use `bun`** - never npm/yarn
+- **NEVER run dev/build commands** (`bun dev`, `bun build`)
+
+## Commands
+
+### Root Commands
+
+- Type check all: `bun run check:all`
+- Format all: `bun run format:all`
+
+### Package-Specific Commands
+
+After making changes in a specific package, run its check script:
+
+| Package           | Check Command          | Format Command          |
+| ----------------- | ---------------------- | ----------------------- |
+| `apps/cli`        | `bun run check:cli`    | `bun run format:cli`    |
+| `apps/web`        | `bun run check:web`    | `bun run format:web`    |
+| `packages/shared` | `bun run check:shared` | `bun run format:shared` |
+
 <!-- effect-solutions:start -->
 
 ## Effect Solutions Usage
@@ -22,10 +44,6 @@ The Effect Solutions CLI provides curated best practices and patterns for Effect
 - **Imports**: External packages first, then local. Use `.ts` extensions for local imports.
 - **Bun APIs**: Prefer `Bun.file`, `Bun.serve`, `bun:sqlite`, `Bun.$` over Node equivalents.
 - **Testing**: Use `bun:test` with `import { test, expect } from "bun:test"`.
-
-## Scripts
-
-- run `bun check` to check for errors
 
 ## Error Handling
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -36,7 +36,7 @@
 		"build:targets": "bun run scripts/build-binaries.ts",
 		"build": "bun run build:js && bun run build:targets",
 		"check": "tsgo --noEmit",
-		"prepare": "effect-language-service patch",
+		"format": "prettier --write .",
 		"dev": "bun run src/tui-solid/App.tsx",
 		"db:generate": "drizzle-kit generate",
 		"db:sync": "bun run db:generate && bun scripts/sync-schema-sql.ts",
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@btca/shared": "workspace:*",
 		"@effect/cli": "^0.72.1",
-		"@effect/language-service": "^0.62.5",
+		"@effect/language-service": "^0.63.2",
 		"@effect/platform": "^0.93.8",
 		"@effect/platform-bun": "^0.85.0",
 		"@effect/printer": "^0.47.0",
@@ -57,13 +57,14 @@
 		"@shikijs/langs": "^3.20.0",
 		"@shikijs/themes": "^3.20.0",
 		"@types/bun": "latest",
+		"@typescript/native-preview": "^7.0.0-dev.20251231.1",
 		"better-sqlite3": "^12.5.0",
 		"drizzle-kit": "^0.31.8",
 		"drizzle-orm": "^0.45.1",
 		"effect": "^3.19.13",
 		"marked": "^17.0.1",
+		"prettier": "^3.7.4",
 		"shiki": "^3.20.0",
-		"solid-js": "^1.9.10",
-		"typescript": "^5.9.3"
+		"solid-js": "^1.9.10"
 	}
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,8 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.1.17",
-		"prettier": "^3.6.2",
+		"@typescript/native-preview": "^7.0.0-dev.20251231.1",
+		"prettier": "^3.7.4",
 		"prettier-plugin-svelte": "^3.4.0",
 		"prettier-plugin-tailwindcss": "^0.7.1",
 		"rollup-plugin-visualizer": "^6.0.5",
@@ -27,7 +28,6 @@
 		"svelte": "^5.43.8",
 		"svelte-check": "^4.3.4",
 		"tailwindcss": "^4.1.17",
-		"typescript": "^5.9.3",
 		"vite": "^7.2.2",
 		"vite-plugin-devtools-json": "^1.0.0"
 	},

--- a/apps/web/src/lib/stores/ThemeStore.svelte.ts
+++ b/apps/web/src/lib/stores/ThemeStore.svelte.ts
@@ -60,4 +60,3 @@ export const setThemeStore = () => {
 	const newStore = new ThemeStore();
 	return internalSet(newStore);
 };
-

--- a/apps/web/src/routes/getting-started/+page.svelte
+++ b/apps/web/src/routes/getting-started/+page.svelte
@@ -133,8 +133,8 @@ Available resources: svelte, tailwindcss`;
 		<p class="mt-2 max-w-2xl text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
 			Use <code class="rounded bg-neutral-900/5 px-1 py-0.5 text-xs dark:bg-white/10">ask</code> for
 			a single question, or
-			<code class="rounded bg-neutral-900/5 px-1 py-0.5 text-xs dark:bg-white/10">chat</code> for an
-			interactive session.
+			<code class="rounded bg-neutral-900/5 px-1 py-0.5 text-xs dark:bg-white/10">chat</code> for an interactive
+			session.
 		</p>
 
 		<div class="mt-4 grid gap-4 md:grid-cols-2">

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "@btca/repo",
       "devDependencies": {
+        "@effect/language-service": "^0.63.0",
         "@opentui/solid": "^0.1.67",
         "@types/bun": "^1.3.5",
         "@typescript/native-preview": "^7.0.0-dev.20251230.1",
-        "prettier": "^3.7.4",
         "turbo": "^2.7.2",
         "typescript": "^5.9.3",
       },
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@btca/shared": "workspace:*",
         "@effect/cli": "^0.72.1",
-        "@effect/language-service": "^0.62.5",
+        "@effect/language-service": "^0.63.2",
         "@effect/platform": "^0.93.8",
         "@effect/platform-bun": "^0.85.0",
         "@effect/printer": "^0.47.0",
@@ -34,14 +34,15 @@
         "@shikijs/langs": "^3.20.0",
         "@shikijs/themes": "^3.20.0",
         "@types/bun": "latest",
+        "@typescript/native-preview": "^7.0.0-dev.20251231.1",
         "better-sqlite3": "^12.5.0",
         "drizzle-kit": "^0.31.8",
         "drizzle-orm": "^0.45.1",
         "effect": "^3.19.13",
         "marked": "^17.0.1",
+        "prettier": "^3.7.4",
         "shiki": "^3.20.0",
         "solid-js": "^1.9.10",
-        "typescript": "^5.9.3",
       },
     },
     "apps/web": {
@@ -60,7 +61,8 @@
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.17",
-        "prettier": "^3.6.2",
+        "@typescript/native-preview": "^7.0.0-dev.20251231.1",
+        "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.0",
         "prettier-plugin-tailwindcss": "^0.7.1",
         "rollup-plugin-visualizer": "^6.0.5",
@@ -68,7 +70,6 @@
         "svelte": "^5.43.8",
         "svelte-check": "^4.3.4",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3",
         "vite": "^7.2.2",
         "vite-plugin-devtools-json": "^1.0.0",
       },
@@ -78,9 +79,8 @@
       "version": "0.0.1",
       "devDependencies": {
         "@types/bun": "latest",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
+        "@typescript/native-preview": "^7.0.0-dev.20251231.1",
+        "prettier": "^3.7.4",
       },
     },
   },
@@ -157,7 +157,7 @@
 
     "@effect/experimental": ["@effect/experimental@0.57.11", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.93.6", "effect": "^3.19.9", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-M5uug3Drs/gyTHLfA+XzcIZQGUEV/Jn5yi1POki4oZswhpzNmsVTHl4THpxAordRKwa5lFvTSlsRP684YH7pSw=="],
 
-    "@effect/language-service": ["@effect/language-service@0.62.5", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-vCMZkqbE8bQ4cmksrj2HLVhYXL6B0bs7uulALgVh6Hh46/V2WrcExgx6DTr0BE6nwBuecqbd4xWjEoPSwI8bPw=="],
+    "@effect/language-service": ["@effect/language-service@0.63.2", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-/y33gKaZiG+kWKbs2kogmUAItFta5VVzBChdNCqzQ0E9SFfBf7TapwtN5OgTMNJMcyv41R4zaTGVM4Iqtv7hZQ=="],
 
     "@effect/platform": ["@effect/platform@0.93.8", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.12" } }, "sha512-xTEy6fyTy4ijmFC3afKgtvYtn/JyPoIov4ZSUWJZUv3VeOcUPNGrrqG6IJlWkXs3NhvSywKv7wc1kw3epCQVZw=="],
 

--- a/package.json
+++ b/package.json
@@ -22,19 +22,27 @@
 	},
 	"packageManager": "bun@1.3.5",
 	"scripts": {
-		"clean": "find . -type d \\( -name node_modules -o -name .svelte-kit -o -name .turbo -o -name .vercel \\) -prune -exec rm -rf {} +",
-		"dev": "turbo run dev",
+		"prepare": "effect-language-service patch",
+		"dev": "turbo dev --ui tui",
 		"cli": "bun run apps/cli/src/index.ts",
-		"build:cli": "turbo run build --filter=btca",
-		"build:web": "turbo run build --filter=@btca/web",
-		"build:all": "turbo run build",
-		"check": "turbo run check"
+		"build:all": "turbo build",
+		"build:cli": "turbo build --filter=btca",
+		"build:web": "turbo build --filter=@btca/web",
+		"check:all": "turbo check",
+		"check:cli": "turbo check --filter=btca",
+		"check:web": "turbo check --filter=@btca/web",
+		"check:shared": "turbo check --filter=@btca/shared",
+		"format:all": "turbo format",
+		"format:cli": "turbo format --filter=btca",
+		"format:web": "turbo format --filter=@btca/web",
+		"format:shared": "turbo format --filter=@btca/shared",
+		"clean": "find . -type d \\( -name node_modules -o -name .svelte-kit -o -name .turbo -o -name .vercel \\) -prune -exec rm -rf {} +"
 	},
 	"devDependencies": {
+		"@effect/language-service": "^0.63.0",
 		"@opentui/solid": "^0.1.67",
 		"@types/bun": "^1.3.5",
 		"@typescript/native-preview": "^7.0.0-dev.20251230.1",
-		"prettier": "^3.7.4",
 		"turbo": "^2.7.2",
 		"typescript": "^5.9.3"
 	}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,10 +7,13 @@
 	"exports": {
 		".": "./src/index.ts"
 	},
-	"devDependencies": {
-		"@types/bun": "latest"
+	"scripts": {
+		"check": "tsgo --noEmit",
+		"format": "prettier --write ."
 	},
-	"peerDependencies": {
-		"typescript": "^5"
+	"devDependencies": {
+		"@types/bun": "latest",
+		"@typescript/native-preview": "^7.0.0-dev.20251231.1",
+		"prettier": "^3.7.4"
 	}
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,29 +1,29 @@
 {
-  "compilerOptions": {
-    // Environment setup & latest features
-    "lib": ["ESNext"],
-    "target": "ESNext",
-    "module": "Preserve",
-    "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
 
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
 
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
 
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
-  }
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,13 +2,17 @@
 	"$schema": "https://turborepo.com/schema.json",
 	"tasks": {
 		"build": {
+			"dependsOn": ["^build"],
 			"outputs": [".svelte-kit/**", "dist/**", ".vercel/**"]
+		},
+		"format": {
+			"dependsOn": ["^format"]
+		},
+		"check": {
+			"dependsOn": ["^check"]
 		},
 		"dev": {
 			"persistent": true,
-			"cache": false
-		},
-		"check": {
 			"cache": false
 		}
 	}


### PR DESCRIPTION
updated stuff li

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR migrates the repository from standard TypeScript to `@typescript/native-preview` (which provides the `tsgo` command), adds comprehensive formatting scripts across all packages, and updates the AGENTS.md guide with critical rules and reorganized command documentation.

**Key changes:**
- Replaced `typescript` with `@typescript/native-preview` in workspace packages (CLI, web, shared)
- Added `format` scripts to all packages using `prettier`
- Restructured root scripts with granular `check:*` and `format:*` commands for each package
- Updated `turbo.json` to add proper dependency chains (`dependsOn`) for build, check, and format tasks
- Enhanced AGENTS.md with critical rules section emphasizing bun-only usage and prohibiting dev/build commands
- Root `package.json` moved `prettier` to child packages and added `@effect/language-service` with prepare script
- Minor formatting cleanup in web app files (trailing newlines, line wrapping)

<h3>Confidence Score: 4/5</h3>


- This PR is generally safe to merge with minor verification needed
- The changes are primarily dependency updates and tooling improvements. The main risk is the migration from `typescript` to `@typescript/native-preview` - while `tsgo` should work as a drop-in replacement for `tsc`, this should be verified by running the check scripts. The root `package.json` still includes `typescript` as a fallback. All other changes (formatting scripts, turbo config updates, documentation) are low-risk improvements.
- Verify that `apps/cli/package.json` and `packages/shared/package.json` check scripts work correctly with `tsgo` from `@typescript/native-preview`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Added critical rules section and reorganized command documentation for better clarity |
| package.json | Restructured scripts with new check/format commands for all packages, added prepare script |
| apps/cli/package.json | Removed typescript dependency, added @typescript/native-preview and prettier, updated prepare script |
| packages/shared/package.json | Converted peerDependencies to devDependencies, added check/format scripts, includes @typescript/native-preview |
| turbo.json | Added dependsOn chains for build, format, and check tasks to properly handle workspace dependencies |

</details>



<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->