### PR TITLE
feat(cli): remove cached repo on resource delete

### DIFF
--- a/apps/cli/src/services/cli.ts
+++ b/apps/cli/src/services/cli.ts
@@ -513,6 +513,11 @@ const configResourcesRemoveCommand = Command.make(
 				return;
 			}
 
+			// Remove cached repo folder (only applies to git resources)
+			yield* services.resources.remove(resourceName).pipe(
+				Effect.catchAll(() => Effect.void) // Ignore if not cached
+			);
+
 			yield* services.config.removeResource(resourceName);
 			console.log(`Removed resource "${resourceName}".`);
 		}).pipe(
@@ -842,4 +847,4 @@ const cliService = Effect.gen(function* () {
 
 export class CliService extends Effect.Service<CliService>()('CliService', {
 	effect: cliService
-}) {}
+}) { }

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "apps/web": {
       "name": "@btca/web",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@btca/shared": "workspace:*",
         "@lucide/svelte": "^0.560.0",


### PR DESCRIPTION
I was addressing this [issue](https://github.com/davis7dotsh/better-context/issues/40)

When removing a git resource from the configuration, also remove the corresponding cached repository folder. This ensures proper cleanup and prevents stale cache data from accumulating.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added automatic cache cleanup when removing git resources from configuration. When a resource is deleted via `btca config resources remove`, the CLI now also removes the corresponding cached repository folder from the resources directory.

- The cleanup uses `services.resources.remove()` which handles git resource cache deletion
- Wrapped in `Effect.catchAll(() => Effect.void)` to gracefully ignore errors (e.g., when resource isn't cached or is a local resource)
- Maintains backward compatibility - local resources are handled gracefully with no side effects
- Prevents accumulation of stale cache data from deleted resources

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is well-isolated, adds defensive error handling via catchAll, and properly integrates with existing resource service methods. The implementation correctly handles both git and local resources without breaking existing behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/services/cli.ts | Added cache cleanup call to remove cached git repo when resource is deleted from config. Uses catchAll to silently ignore errors for non-git resources. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->