### PR TITLE
feat: config schema

### DIFF
--- a/apps/cli/src/core/config/service.ts
+++ b/apps/cli/src/core/config/service.ts
@@ -5,6 +5,7 @@ import {
 	type Config,
 	CONFIG_DIRECTORY,
 	CONFIG_FILENAME,
+	CONFIG_SCHEMA_URL,
 	DEFAULT_DATA_DIRECTORY,
 	DEFAULT_MODEL,
 	DEFAULT_PROVIDER,
@@ -72,6 +73,7 @@ interface MigratedResource {
 }
 
 interface MigratedConfig {
+	$schema: string;
 	resources: MigratedResource[];
 	model: string;
 	provider: string;
@@ -109,6 +111,7 @@ const migrateConfig = (parsed: Record<string, unknown>): MigratedConfig => {
 	});
 
 	const result: MigratedConfig = {
+		$schema: CONFIG_SCHEMA_URL,
 		resources,
 		model: String(parsed.model ?? DEFAULT_MODEL),
 		provider: String(parsed.provider ?? DEFAULT_PROVIDER)
@@ -144,6 +147,7 @@ const loadConfig = Effect.gen(function* () {
 			.pipe(Effect.catchAll(() => Effect.void));
 
 		const defaultStored: typeof StoredConfigSchema.Type = {
+			$schema: CONFIG_SCHEMA_URL,
 			resources: DEFAULT_RESOURCES,
 			model: DEFAULT_MODEL,
 			provider: DEFAULT_PROVIDER
@@ -241,6 +245,7 @@ const createConfigService = Effect.gen(function* () {
 
 	const saveConfig = Effect.gen(function* () {
 		const stored: typeof StoredConfigSchema.Type = {
+			$schema: CONFIG_SCHEMA_URL,
 			dataDirectory: collapseHome(config.dataDirectory),
 			resources: config.resources,
 			model: config.model,

--- a/apps/cli/src/core/config/types.ts
+++ b/apps/cli/src/core/config/types.ts
@@ -5,6 +5,7 @@ import { GitResourceSchema, ResourceDefinitionSchema } from '../resource/types.t
 export const CONFIG_DIRECTORY = '~/.config/btca';
 export const CONFIG_FILENAME = 'btca.json';
 export const DEFAULT_DATA_DIRECTORY = '~/.local/share/btca';
+export const CONFIG_SCHEMA_URL = 'https://btca.dev/btca.schema.json';
 
 // Legacy repo schema (for migration)
 export const LegacyRepoSchema = Schema.Struct({
@@ -28,6 +29,7 @@ export const LegacyConfigSchema = Schema.Struct({
 
 // New config schema with resources instead of repos
 export const StoredConfigSchema = Schema.Struct({
+	$schema: Schema.optional(Schema.String), // JSON schema URL for LSP support
 	dataDirectory: Schema.optional(Schema.String), // defaults to ~/.local/share/btca
 	resources: Schema.Array(ResourceDefinitionSchema),
 	model: Schema.String,

--- a/apps/web/static/btca.schema.json
+++ b/apps/web/static/btca.schema.json
@@ -1,0 +1,109 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://btca.dev/btca.schema.json",
+	"title": "btca Configuration",
+	"description": "Configuration file for btca (Better Context Agent)",
+	"type": "object",
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"description": "JSON Schema reference for IDE support"
+		},
+		"dataDirectory": {
+			"type": "string",
+			"description": "Directory for storing btca data (resources, collections). Defaults to ~/.local/share/btca",
+			"default": "~/.local/share/btca"
+		},
+		"model": {
+			"type": "string",
+			"description": "The model to use for AI interactions",
+			"default": "big-pickle"
+		},
+		"provider": {
+			"type": "string",
+			"description": "The AI provider to use",
+			"default": "opencode"
+		},
+		"resources": {
+			"type": "array",
+			"description": "List of resources (documentation repositories or local directories) to use for context",
+			"items": {
+				"oneOf": [
+					{
+						"$ref": "#/$defs/gitResource"
+					},
+					{
+						"$ref": "#/$defs/localResource"
+					}
+				]
+			},
+			"default": []
+		}
+	},
+	"required": ["model", "provider", "resources"],
+	"additionalProperties": false,
+	"$defs": {
+		"gitResource": {
+			"type": "object",
+			"title": "Git Resource",
+			"description": "A resource cloned from a remote git repository",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "git",
+					"description": "Resource type identifier"
+				},
+				"name": {
+					"type": "string",
+					"description": "Unique name for this resource"
+				},
+				"url": {
+					"type": "string",
+					"description": "Git repository URL",
+					"format": "uri"
+				},
+				"branch": {
+					"type": "string",
+					"description": "Git branch to use",
+					"default": "main"
+				},
+				"searchPath": {
+					"type": "string",
+					"description": "Subdirectory within the repo to focus searches on"
+				},
+				"specialNotes": {
+					"type": "string",
+					"description": "Additional context or notes about this resource for the AI"
+				}
+			},
+			"required": ["type", "name", "url", "branch"],
+			"additionalProperties": false
+		},
+		"localResource": {
+			"type": "object",
+			"title": "Local Resource",
+			"description": "A resource from a local directory (symlinked)",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "local",
+					"description": "Resource type identifier"
+				},
+				"name": {
+					"type": "string",
+					"description": "Unique name for this resource"
+				},
+				"path": {
+					"type": "string",
+					"description": "Absolute path to the local directory"
+				},
+				"specialNotes": {
+					"type": "string",
+					"description": "Additional context or notes about this resource for the AI"
+				}
+			},
+			"required": ["type", "name", "path"],
+			"additionalProperties": false
+		}
+	}
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added JSON schema support for btca config files to enable IDE autocomplete and validation. The PR adds a `$schema` field to config files that points to `https://btca.dev/btca.schema.json`.

- Created comprehensive JSON schema file (`btca.schema.json`) with full definitions for git and local resources
- Updated config type definitions to include optional `$schema` field
- Modified config service to automatically include `$schema` in all saved configs (new, migrated, and updated)
- Existing configs without `$schema` remain compatible since the field is optional
- Schema is served from `/static` directory which SvelteKit automatically exposes at the root URL

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are purely additive - they add IDE support without breaking existing functionality. The `$schema` field is optional in both the TypeScript and JSON schemas, ensuring full backward compatibility with existing config files. All config save operations now include the schema reference for better developer experience.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/core/config/types.ts | Added `CONFIG_SCHEMA_URL` constant and optional `$schema` field to `StoredConfigSchema` for LSP/IDE autocomplete support |
| apps/cli/src/core/config/service.ts | Updated config migration, loading, and saving logic to include `$schema` field in all config file writes |
| apps/web/static/btca.schema.json | New JSON schema file that defines the btca config structure for IDE validation and autocomplete |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->