### PR TITLE
[cli] fix: resolve cerebras provider and skill integration issues in docs agent

### DIFF
--- a/apps/cli/src/core/agent/service.ts
+++ b/apps/cli/src/core/agent/service.ts
@@ -88,7 +88,6 @@ export const buildOpenCodeConfig = (args: { resources: ResourceInfo[] }): OpenCo
 			plan: { disable: true },
 			docs: {
 				prompt,
-				disable: false,
 				description: 'Get answers about libraries and frameworks by searching their source code',
 				permission: {
 					webfetch: 'deny',
@@ -109,7 +108,12 @@ export const buildOpenCodeConfig = (args: { resources: ResourceInfo[] }): OpenCo
 					path: false,
 					todowrite: false,
 					todoread: false,
-					websearch: false
+					websearch: false,
+					webfetch: false,
+					skill: false, // TODO - GLM 4.6 hangs when skills enabled
+					task: false,
+					mcp: false,
+					edit: false
 				}
 			}
 		}


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Removes the problematic `disable: false` field from the docs agent config that was causing Cerebras provider to reject requests, and disables several tools (skill, task, mcp, edit, webfetch) to prevent btca CLI from exiting prematurely.

- ✅ Removing `disable: false` fixes Cerebras compatibility (provider doesn't recognize this field)
- ✅ Disabling skill, task, mcp, and edit tools prevents premature CLI exit
- ⚠️ `webfetch: false` in tools is redundant since `permission.webfetch: 'deny'` already blocks it
- ⚠️ The TODO comment references "GLM 4.6" but testing was done with "zai-glm-4.7" - verify this is intentional or update comment

### Confidence Score: 4/5

- This PR is safe to merge with minimal risk
- Score reflects that the changes fix real issues (Cerebras compatibility and CLI stability) with minimal code modifications. The removal of `disable: false` is correct since it was redundant (other agents use `disable: true` to disable them, and the docs agent has `mode: 'primary'` to mark it as primary). The only concerns are minor: redundant webfetch restriction and potential TODO comment discrepancy. No breaking changes or logic errors detected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/cli/src/core/agent/service.ts | 3/5 | Removes `disable: false` from docs agent config and disables webfetch, skill, task, mcp, and edit tools. Issue: `webfetch` is now disabled in both `permission` and `tools`, creating redundancy. |

</details>

