### PR TITLE
Update documentation to use full flag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ btca --help
 Ask a question:
 
 ```bash
-btca ask -t svelte -q "How do stores work in Svelte 5?"
+btca ask --resource svelte --question "How do stores work in Svelte 5?"
 ```
 
 Open the TUI:
 
 ```bash
-btca chat -t svelte
+btca chat --resource svelte
 ```
 
 Run as a server:
 
 ```bash
-btca serve -p 8080
+btca serve --port 8080
 ```
 
 Then POST `/question` with:
@@ -57,19 +57,19 @@ Default resources: svelte, effect, nextjs. Add more:
 
 ```bash
 # Git repo
-btca config resources add -n react -u https://github.com/facebook/react -b main
+btca config resources add --name react --url https://github.com/facebook/react --branch main
 
 # With search path (limits where agent searches)
-btca config resources add -n nextjs-docs -u https://github.com/vercel/next.js -b canary --search-path docs
+btca config resources add --name nextjs-docs --url https://github.com/vercel/next.js --branch canary --search-path docs
 
 # Local directory
-btca config resources add -n myproject --type local --path ~/code/myproject
+btca config resources add --name myproject --type local --path ~/code/myproject
 ```
 
 List/remove:
 ```bash
 btca config resources list
-btca config resources remove -n react
+btca config resources remove --name react
 ```
 
 ## stuff I want to add

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -6,8 +6,8 @@
 	const INSTALL_CMD = `bun add -g btca opencode-ai && btca`;
 	const CURSOR_CMD = `mkdir -p .cursor/rules && curl -fsSL "https://btca.dev/rule" -o .cursor/rules/better_context.mdc && echo "Rule file created."`;
 
-	const ASK_CMD = `btca ask -r svelte -q "How does the $state rune work?"`;
-	const CHAT_CMD = `btca chat -r svelte`;
+	const ASK_CMD = `btca ask --resource svelte --question "How does the $state rune work?"`;
+	const CHAT_CMD = `btca chat --resource svelte`;
 
 	const shikiStore = getShikiStore();
 	const themeStore = getThemeStore();

--- a/apps/web/src/routes/commands/+page.svelte
+++ b/apps/web/src/routes/commands/+page.svelte
@@ -13,12 +13,12 @@
 			name: 'btca ask',
 			description:
 				'Ask a single question about configured resources and get an answer from their source code.',
-			example: 'btca ask -r runed -q "How does useDebounce work?"'
+			example: 'btca ask --resource runed --question "How does useDebounce work?"'
 		},
 		{
 			name: 'btca chat',
 			description: 'Open an interactive TUI session for multi-turn conversations about resources.',
-			example: 'btca chat -r runed'
+			example: 'btca chat --resource runed'
 		},
 		{
 			name: 'btca config',
@@ -28,7 +28,7 @@
 		{
 			name: 'btca config model',
 			description: 'View or set the AI model and provider used for answering questions.',
-			example: 'btca config model -p opencode -m claude-haiku-4-5'
+			example: 'btca config model --provider opencode --model claude-haiku-4-5'
 		},
 		{
 			name: 'btca config resources list',
@@ -39,17 +39,17 @@
 			name: 'btca config resources add (git)',
 			description: 'Add a new git repository as a resource.',
 			example:
-				'btca config resources add -n runed -t git -u https://github.com/svecosystem/runed -b main'
+				'btca config resources add --name runed --type git --url https://github.com/svecosystem/runed --branch main'
 		},
 		{
 			name: 'btca config resources add (local)',
 			description: 'Add a local directory as a resource.',
-			example: 'btca config resources add -n myproject -t local --path /path/to/project'
+			example: 'btca config resources add --name myproject --type local --path /path/to/project'
 		},
 		{
 			name: 'btca config resources remove',
 			description: 'Remove a resource from the configuration.',
-			example: 'btca config resources remove -n runed'
+			example: 'btca config resources remove --name runed'
 		},
 		{
 			name: 'btca config collections list',


### PR DESCRIPTION
## Summary
Updated all CLI examples in the README and website to use descriptive long-form flags (--resource, --question, --name, etc.) instead of single-letter shorthands (-r, -q, -n) for better clarity and readability.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR updates CLI documentation examples from shorthand flags (like `-r`, `-q`, `-n`) to full flag names (like `--resource`, `--question`, `--name`) for improved clarity and readability.

## What Changed
- **README.md**: Updated examples for `ask`, `chat`, `serve`, and `config resources` commands
- **apps/web/src/routes/+page.svelte**: Updated homepage command examples
- **apps/web/src/routes/commands/+page.svelte**: Updated all command reference examples

## Verification
All flag changes are valid and match the actual CLI implementation in `apps/cli/src/services/cli.ts`:
- `--resource` (alias `-r`) ✅
- `--question` (alias `-q`) ✅
- `--name` (alias `-n`) ✅
- `--url` (alias `-u`) ✅
- `--branch` (alias `-b`) ✅
- `--provider` (alias `-p`) ✅
- `--model` (alias `-m`) ✅
- `--type` (alias `-t`) ✅
- `--port` (documented but command doesn't exist) ⚠️

## Issues Found
1. **Documentation references non-existent command**: README.md documents `btca serve --port 8080`, but this command is not implemented in the current CLI
2. **Incomplete update**: Many other documentation files still use shorthand notation, creating inconsistency across the codebase

### Confidence Score: 4/5

- This PR is safe to merge - it's documentation-only with no code changes
- Documentation changes are valid and won't break functionality, but the PR is incomplete (many files not updated) and references a non-existent command
- README.md needs attention for the non-existent `serve` command reference. Other documentation files not included in this PR should be updated for consistency.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 4/5 | Updated CLI examples from shorthand to full flag names. Changes are valid but inconsistent with other documentation files. |
| apps/web/src/routes/+page.svelte | 4/5 | Updated example commands from -r/-q to --resource/--question. Changes are correct and won't break functionality. |
| apps/web/src/routes/commands/+page.svelte | 4/5 | Updated all command examples to use full flag names. All changes are valid and match actual CLI implementation. |

</details>



<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->