### PR TITLE
Normalize GitHub URLs when adding git resources

### DIFF
--- a/apps/cli/src/core/resource/strategies/git.ts
+++ b/apps/cli/src/core/resource/strategies/git.ts
@@ -57,8 +57,7 @@ const cloneRepo = (args: {
 
 		yield* fs.makeDirectory(repoDir, { recursive: true });
 
-		// Validate inputs to prevent injection attacks
-		yield* validateGitUrl(url);
+		const normalizedUrl = yield* validateGitUrl(url);
 		yield* validateBranchName(branch);
 		if (searchPath) {
 			yield* validateSearchPath(searchPath);
@@ -66,7 +65,7 @@ const cloneRepo = (args: {
 
 		// Use '--' delimiter to prevent git option injection
 		yield* runGit(['init', '--', repoDir], { quiet });
-		yield* runGit(['remote', 'add', 'origin', '--', url], { cwd: repoDir, quiet });
+		yield* runGit(['remote', 'add', 'origin', '--', normalizedUrl], { cwd: repoDir, quiet });
 
 		if (searchPath) {
 			yield* runGit(['config', 'core.sparseCheckout', 'true'], { cwd: repoDir, quiet });

--- a/apps/cli/src/services/cli.ts
+++ b/apps/cli/src/services/cli.ts
@@ -460,14 +460,14 @@ const configResourcesAddCommand = Command.make(
 				resource = localResource;
 			}
 
-			yield* services.config.addResource(resource);
-			console.log(`Added ${type} resource "${resourceName}"`);
+			const addedResource = yield* services.config.addResource(resource);
+			console.log(`Added ${type} resource "${addedResource.name}"`);
 
-			if (isGitResource(resource)) {
-				console.log(`  URL: ${resource.url}`);
-				console.log(`  Branch: ${resource.branch}`);
+			if (isGitResource(addedResource)) {
+				console.log(`  URL: ${addedResource.url}`);
+				console.log(`  Branch: ${addedResource.branch}`);
 			} else {
-				console.log(`  Path: ${resource.path}`);
+				console.log(`  Path: ${addedResource.path}`);
 			}
 		}).pipe(
 			Effect.catchTag('ConfigError', (e) =>


### PR DESCRIPTION
## Summary

I often cloned with the wrong URL by mistake (copying from browser while viewing a file) and it caused hard to debug issues. Now URLs like `https://github.com/owner/repo/blob/main/README.md` get normalized to `https://github.com/owner/repo`.
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds automatic normalization of GitHub URLs when adding git resources. The implementation correctly strips extra path segments like `/blob/main/file.txt` or `/tree/branch/path` from GitHub URLs to get the base repository URL (`https://github.com/owner/repo`). 

**Key Changes:**
- Modified `validateGitUrl` to return the normalized URL instead of void
- Added `normalizeGitHubUrl` function that extracts owner/repo from pathname and removes `.git` suffix
- Updated all call sites to capture and use the normalized URL
- CLI now displays the normalized URL to users, providing clear feedback

**Behavior:**
- GitHub URLs are normalized to base format (https://github.com/owner/repo)
- Non-GitHub URLs are passed through unchanged
- Only affects newly added resources; existing resources remain unchanged until re-added
- Git operations use normalized URLs, preventing issues from browser-copied URLs

The implementation maintains all existing security validations (HTTPS-only, no credentials, no private IPs) and handles edge cases properly (trailing slashes, query parameters, multiple path segments, .git suffix).

### Confidence Score: 5/5

- This PR is safe to merge with no significant risks
- All changes are well-implemented with proper error handling. The normalization logic correctly handles edge cases (empty segments, .git suffix, extra path components). All call sites are updated to handle the new return type. The change is backwards compatible - existing resources continue to work, and git operations will use normalized URLs even for old configs. No breaking changes to existing functionality.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/cli/src/core/validation/resource.ts | 5/5 | Adds GitHub URL normalization - strips path segments like /blob/ and /tree/ to get base repo URL. Logic is sound and handles edge cases well. |
| apps/cli/src/core/config/service.ts | 5/5 | Updates to capture and save normalized URL from validation. Correctly creates new resource object and returns it. |
| apps/cli/src/core/resource/strategies/git.ts | 5/5 | Uses normalized URL when adding git remote. Clean implementation that maintains security validations. |
| apps/cli/src/services/cli.ts | 5/5 | Displays normalized URL to user after adding resource. Improves UX by showing what was actually saved. |

</details>



<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->