### PR TITLE
Show resource path/URL in picker for remove command

### DIFF
--- a/apps/cli/src/lib/utils/colors.ts
+++ b/apps/cli/src/lib/utils/colors.ts
@@ -1,0 +1,1 @@
+export const dim = (text: string) => `\x1b[2m${text}\x1b[0m`;


### PR DESCRIPTION

<img width="572" height="129" alt="image" src="https://github.com/user-attachments/assets/0d7ebe17-6263-4091-b824-f95aee9d4665" />


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR enhances the resource removal command by displaying both the resource name and its location (path or URL) in the interactive picker. 

**Changes made:**
- Created a new `dim()` utility function in `colors.ts` using ANSI escape codes for dimmed text styling
- Updated `selectSingleResource()` to accept full `ResourceDefinition` objects instead of just names
- Modified the picker display format to show: `resource-name (dimmed-path-or-url)` 
- Fixed the empty resources check to use `resources.length` instead of `names.length` (more semantically correct)
- Return value remains `resource.name` (string), maintaining compatibility with existing validation logic

**Integration with codebase:**
The changes integrate cleanly with the existing architecture:
- Follows the project's import conventions (`.ts` extensions)
- Uses existing type guards (`isGitResource`) for proper type discrimination
- The function is only called in one location (`configResourcesRemoveCommand`), which was updated accordingly
- The `names` variable is still computed and used for validation (line 514), so no breaking changes to downstream logic
- Consistent with the project's use of ANSI codes and terminal output patterns

**Impact:**
This is a focused UX improvement that helps users identify resources more easily when removing them, without affecting any other functionality.

### Confidence Score: 5/5

- This PR is safe to merge with no identified risks
- Score of 5 reflects that this is a well-implemented, focused change with no bugs or breaking changes. The code is type-safe, follows project conventions, maintains backward compatibility, and the only call site was properly updated. The empty resources check improvement (using resources.length instead of names.length) is semantically clearer without changing behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/cli/src/lib/utils/colors.ts | 5/5 | New utility file with dim() function for ANSI text styling - clean implementation |
| apps/cli/src/services/cli.ts | 5/5 | Enhanced resource picker to display path/URL with dimmed styling, updated function signature and fixed length check - all changes work correctly |

</details>



<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->