### PR TITLE
Increase Bun.serve idleTimeout to 60 seconds

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -461,7 +461,8 @@ export const startServer = async (options: StartServerOptions = {}): Promise<Ser
 
 	const server = Bun.serve({
 		port: requestedPort,
-		fetch: app.fetch
+		fetch: app.fetch,
+		idleTimeout: 60
 	});
 
 	const actualPort = server.port ?? requestedPort;


### PR DESCRIPTION
## Problem

The default `idleTimeout` of 10 seconds in `Bun.serve` is too short for slow OpenCode startup times. On some systems (mine), OpenCode can take 27+ seconds just to initialize, causing timeout errors during collection creation with the error:

```
[Bun.serve]: request timed out after 10 seconds
TypeError: Invalid state: Controller is already closed
```

## Solution

Increased `idleTimeout` to 60 seconds to accommodate slow OpenCode startup. OpenCode has been buggy for me and slow to fix issues, so startup sometimes takes significantly longer than expected.

## Changes

- `apps/server/src/index.ts`: Set `idleTimeout: 60` in `Bun.serve` configuration

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Increased `Bun.serve` `idleTimeout` from default 10 seconds to 60 seconds to accommodate slow OpenCode startup times that can exceed 27 seconds on some systems.

- Prevents timeout errors during collection creation when OpenCode takes longer to initialize
- Only change is adding `idleTimeout: 60` parameter to server configuration in `apps/server/src/index.ts:465`
- No breaking changes to existing features

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Single parameter addition with no logic changes. Increasing timeout value is a conservative fix that only makes the server more tolerant of slow operations without breaking existing behavior
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/server/src/index.ts | Added `idleTimeout: 60` to Bun.serve config to prevent timeout errors during slow OpenCode startup |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->