### PR TITLE
Fix collection symlinks for Windows

### DIFF
--- a/apps/server/src/collections/service.ts
+++ b/apps/server/src/collections/service.ts
@@ -97,7 +97,7 @@ export namespace Collections {
 						}
 
 						try {
-							await fs.symlink(resourcePath, linkPath);
+							await fs.symlink(resourcePath, linkPath, 'junction');
 						} catch (cause) {
 							throw new CollectionError({
 								message: `Failed to create symlink for resource "${resource.name}"`,


### PR DESCRIPTION
# Problem
fs.symlink fails on Windows for directories.

# Solution
There's an optional third parameter for https://bun.com/reference/node/fs/promises/symlink that is used only on Windows.
Explicitly specify the type of symlink as junction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds Windows compatibility for directory symlinks by explicitly specifying 'junction' type in `fs.symlink` calls
- Modifies `apps/server/src/collections/service.ts` to include the optional third parameter for Windows filesystem requirements

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| apps/server/src/collections/service.ts | Updated symlink creation to specify 'junction' type for Windows directory symlink compatibility |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with virtually no risk of breaking existing functionality
- Score reflects a minimal, well-targeted change that only adds an optional parameter for Windows compatibility while maintaining backward compatibility on Unix systems
- No files require special attention as the change is isolated and follows documented Node.js/Bun API conventions

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->