### PR TITLE
Add nuxt-skills to community repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Set up btca for this project: scan package.json for major dependencies (framewor
 ```
 
 See the full [Getting Started guide](https://btca.dev/getting-started) for more details.
+
+## Community Repos
+
+- Nuxt 4 + Vue 3 + NuxtHub knowledge base: https://github.com/onmax/nuxt-skills


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a new "Community Repos" section to the README that references the `nuxt-skills` project as a Nuxt 4 + Vue 3 + NuxtHub knowledge base. This is a documentation-only change that does not affect any existing features, code functionality, or build processes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk, as it only adds documentation to the README.
- This PR makes a minimal, non-functional change by adding a single community repository link to the README. There are no code changes, no build process modifications, and no impact on existing features. The change is purely informational.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Added new "Community Repos" section with a link to the nuxt-skills repository. This is a documentation-only change with no impact on code functionality. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->