### PR TITLE
Validate providers and add provider timeout

### DIFF
--- a/apps/cli/src/client/index.ts
+++ b/apps/cli/src/client/index.ts
@@ -65,6 +65,14 @@ export async function getResources(client: Client) {
 	return res.json();
 }
 
+export async function getProviders(client: Client) {
+	const res = await client.providers.$get();
+	if (!res.ok) {
+		throw await parseErrorResponse(res, `Failed to get providers: ${res.status}`);
+	}
+	return res.json();
+}
+
 /**
  * Ask a question (non-streaming)
  */

--- a/apps/server/src/config/index.ts
+++ b/apps/server/src/config/index.ts
@@ -15,6 +15,7 @@ export const CONFIG_SCHEMA_URL = 'https://btca.dev/btca.schema.json';
 
 export const DEFAULT_MODEL = 'claude-haiku-4-5';
 export const DEFAULT_PROVIDER = 'opencode';
+export const DEFAULT_PROVIDER_TIMEOUT_MS = 300_000;
 
 export const DEFAULT_RESOURCES: ResourceDefinition[] = [
 	{
@@ -49,6 +50,7 @@ export const DEFAULT_RESOURCES: ResourceDefinition[] = [
 const StoredConfigSchema = z.object({
 	$schema: z.string().optional(),
 	dataDirectory: z.string().optional(),
+	providerTimeoutMs: z.number().int().positive().optional(),
 	resources: z.array(ResourceDefinitionSchema),
 	model: z.string(),
 	provider: z.string()
@@ -114,6 +116,7 @@ export namespace Config {
 		resources: readonly ResourceDefinition[];
 		model: string;
 		provider: string;
+		providerTimeoutMs?: number;
 		configPath: string;
 		getResource: (name: string) => ResourceDefinition | undefined;
 		updateModel: (provider: string, model: string) => Promise<{ provider: string; model: string }>;
@@ -434,7 +437,8 @@ export namespace Config {
 			$schema: CONFIG_SCHEMA_URL,
 			resources: DEFAULT_RESOURCES,
 			model: DEFAULT_MODEL,
-			provider: DEFAULT_PROVIDER
+			provider: DEFAULT_PROVIDER,
+			providerTimeoutMs: DEFAULT_PROVIDER_TIMEOUT_MS
 		};
 
 		try {
@@ -532,6 +536,9 @@ export namespace Config {
 			},
 			get provider() {
 				return getActiveConfig().provider;
+			},
+			get providerTimeoutMs() {
+				return getActiveConfig().providerTimeoutMs;
 			},
 			getResource: (name: string) => getMergedResources().find((r) => r.name === name),
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -224,6 +224,7 @@ const createApp = (deps: {
 			return c.json({
 				provider: config.provider,
 				model: config.model,
+				providerTimeoutMs: config.providerTimeoutMs ?? null,
 				resourcesDirectory: config.resourcesDirectory,
 				collectionsDirectory: config.collectionsDirectory,
 				resourceCount: config.resources.length
@@ -254,6 +255,12 @@ const createApp = (deps: {
 					}
 				})
 			});
+		})
+
+		// GET /providers
+		.get('/providers', async (c: HonoContext) => {
+			const providers = await agent.listProviders();
+			return c.json(providers);
 		})
 
 		// POST /question

--- a/apps/web/src/lib/assets/docs/SETUP_PROMPT.md
+++ b/apps/web/src/lib/assets/docs/SETUP_PROMPT.md
@@ -75,7 +75,8 @@ Once I approve the resource list, prepare the full `btca.config.jsonc` with sens
 		// ... all approved resources
 	],
 	"model": "claude-haiku-4-5",
-	"provider": "opencode"
+	"provider": "opencode",
+	"providerTimeoutMs": 300000
 }
 ```
 

--- a/apps/web/src/lib/assets/docs/example-btca.config.jsonc
+++ b/apps/web/src/lib/assets/docs/example-btca.config.jsonc
@@ -38,5 +38,6 @@
 
 	// AI model configuration
 	"model": "claude-haiku-4-5",
-	"provider": "opencode"
+	"provider": "opencode",
+	"providerTimeoutMs": 300000
 }

--- a/apps/web/src/routes/config/+page.svelte
+++ b/apps/web/src/routes/config/+page.svelte
@@ -12,6 +12,7 @@
   "$schema": "https://btca.dev/btca.schema.json",
   "model": "claude-haiku-4-5",
   "provider": "opencode",
+  "providerTimeoutMs": 300000,
   "resources": [
     {
       "type": "git",
@@ -97,6 +98,10 @@ Available resources: svelte, effect`;
 		<p class="mt-2 max-w-2xl text-sm bc-prose">
 			btca uses the OpenCode SDK under the hood, so any model that works with OpenCode works with
 			btca. Set your model via CLI or edit the config file directly.
+		</p>
+		<p class="mt-2 max-w-2xl text-sm bc-prose">
+			Providers require credentials configured in OpenCode. Run <code class="bc-inlineCode">opencode auth</code>
+			to connect a provider, or edit your OpenCode config directly.
 		</p>
 
 		<div class="mt-4 flex flex-col gap-4">
@@ -220,6 +225,11 @@ Available resources: svelte, effect`;
 							<td class="py-2 pr-4"><code class="bc-inlineCode">searchPath</code></td>
 							<td class="py-2 pr-4">No</td>
 							<td class="py-2">Subdirectory to search within the repo</td>
+						</tr>
+						<tr class="border-b border-[color:hsl(var(--bc-border))]">
+							<td class="py-2 pr-4"><code class="bc-inlineCode">searchPaths</code></td>
+							<td class="py-2 pr-4">No</td>
+							<td class="py-2">Multiple subdirectories to search within the repo</td>
 						</tr>
 						<tr>
 							<td class="py-2 pr-4"><code class="bc-inlineCode">specialNotes</code></td>

--- a/apps/web/static/btca.schema.json
+++ b/apps/web/static/btca.schema.json
@@ -24,6 +24,11 @@
 			"description": "The AI provider to use",
 			"default": "opencode"
 		},
+		"providerTimeoutMs": {
+			"type": "number",
+			"description": "Timeout in milliseconds for provider requests (optional)",
+			"default": 300000
+		},
 		"resources": {
 			"type": "array",
 			"description": "List of resources (documentation repositories or local directories) to use for context",

--- a/apps/web/static/docs/SETUP_PROMPT.md
+++ b/apps/web/static/docs/SETUP_PROMPT.md
@@ -75,7 +75,8 @@ Once I approve the resource list, prepare the full `btca.config.jsonc` with sens
 		// ... all approved resources
 	],
 	"model": "claude-haiku-4-5",
-	"provider": "opencode"
+	"provider": "opencode",
+	"providerTimeoutMs": 300000
 }
 ```
 

--- a/apps/web/static/docs/example-btca.config.jsonc
+++ b/apps/web/static/docs/example-btca.config.jsonc
@@ -38,5 +38,6 @@
   
   // AI model configuration
   "model": "claude-haiku-4-5",
-  "provider": "opencode"
+  "provider": "opencode",
+  "providerTimeoutMs": 300000
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds provider validation and configurable provider timeout functionality. The changes add a `providerTimeoutMs` config field (default 300000ms) that configures timeout for provider requests through the OpenCode SDK, and implements a new `/providers` endpoint that returns available and connected providers. The CLI `model` command now validates the configured provider and model against available providers, displaying helpful warnings if the provider is invalid, not connected, or if the model doesn't exist.

**Key changes:**
- Added optional `providerTimeoutMs` config field with 5-minute default
- New `listProviders()` agent service method and GET `/providers` endpoint 
- Provider/model validation in CLI with user-friendly warnings
- Updated all documentation and example configs to include the new field
- Config schema updated to include `providerTimeoutMs`

The implementation is solid with proper error handling, validation happens after config updates to provide immediate feedback, and timeout configuration is correctly threaded through to OpenCode SDK. No breaking changes to existing functionality.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-structured, backward compatible (providerTimeoutMs is optional), and add helpful validation without breaking existing features. Error handling is comprehensive with try-catch blocks and fallbacks. The validation logic correctly fails gracefully when providers can't be fetched.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/server/src/config/index.ts | Added `providerTimeoutMs` optional config field with default value 300000ms, properly integrated into config schema and service |
| apps/server/src/agent/service.ts | Added `listProviders` method and integrated `providerTimeoutMs` into OpenCode config, provider timeout properly applied when configured |
| apps/server/src/index.ts | Added GET /providers endpoint and exposed `providerTimeoutMs` in GET /config response |
| apps/cli/src/client/index.ts | Added `getProviders` client function to fetch provider list from server |
| apps/cli/src/commands/config.ts | Added provider/model validation in model command with helpful warnings for invalid, disconnected providers or missing models |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->