### PR TITLE
Add gitpick strategy and clearer branch errors

### DIFF
--- a/apps/cli/src/client/index.ts
+++ b/apps/cli/src/client/index.ts
@@ -186,6 +186,7 @@ export interface GitResourceInput {
 	branch?: string;
 	searchPath?: string;
 	searchPaths?: string[];
+	cloneStrategy?: 'git' | 'gitpick';
 	specialNotes?: string;
 }
 

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -22,6 +22,7 @@ interface GitResource {
 	branch: string;
 	searchPath?: string;
 	searchPaths?: string[];
+	cloneStrategy?: 'git' | 'gitpick';
 	specialNotes?: string;
 }
 
@@ -174,6 +175,7 @@ const resourcesListCommand = new Command('list')
 						} else if (r.searchPath) {
 							console.log(`    Search Path: ${r.searchPath}`);
 						}
+						if (r.cloneStrategy) console.log(`    Clone Strategy: ${r.cloneStrategy}`);
 						if (r.specialNotes) console.log(`    Notes: ${r.specialNotes}`);
 					} else {
 						console.log(`  ${r.name} (local)`);
@@ -200,6 +202,7 @@ const resourcesAddCommand = new Command('add')
 	.option('-b, --branch <branch>', 'Git branch (default: main)')
 	.option('--path <path>', 'Local path (required for local type)')
 	.option('--search-path <searchPath...>', 'Subdirectory to focus on (repeatable)')
+	.option('--clone-strategy <strategy>', 'Clone strategy (git or gitpick)')
 	.option('--notes <notes>', 'Special notes for the AI')
 	.action(async (options, command) => {
 		const globalOpts = command.parent?.parent?.parent?.opts() as
@@ -236,6 +239,9 @@ const resourcesAddCommand = new Command('add')
 					branch: (options.branch as string) ?? 'main',
 					...(searchPaths.length === 1 && { searchPath: searchPaths[0] }),
 					...(searchPaths.length > 1 && { searchPaths }),
+					...(options.cloneStrategy && {
+						cloneStrategy: options.cloneStrategy as 'git' | 'gitpick'
+					}),
 					...(options.notes && { specialNotes: options.notes as string })
 				});
 				// Show normalized URL if it differs from input

--- a/apps/cli/src/tui/services.ts
+++ b/apps/cli/src/tui/services.ts
@@ -46,7 +46,8 @@ export const services = {
 				branch: r.branch ?? 'main',
 				specialNotes: r.specialNotes ?? undefined,
 				searchPath: r.searchPath ?? undefined,
-				searchPaths: r.searchPaths ?? undefined
+				searchPaths: r.searchPaths ?? undefined,
+				cloneStrategy: r.cloneStrategy ?? undefined
 			}));
 	},
 

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -18,6 +18,7 @@ export interface Repo {
 	specialNotes?: string | undefined;
 	searchPath?: string | undefined;
 	searchPaths?: string[] | undefined;
+	cloneStrategy?: 'git' | 'gitpick' | undefined;
 }
 
 export type InputState = (

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -114,6 +114,7 @@ const AddGitResourceRequestSchema = z.object({
 	branch: GitResourceSchema.shape.branch.optional().default('main'),
 	searchPath: GitResourceSchema.shape.searchPath,
 	searchPaths: GitResourceSchema.shape.searchPaths,
+	cloneStrategy: GitResourceSchema.shape.cloneStrategy,
 	specialNotes: GitResourceSchema.shape.specialNotes
 });
 
@@ -243,6 +244,7 @@ const createApp = (deps: {
 							branch: r.branch,
 							searchPath: r.searchPath ?? null,
 							searchPaths: r.searchPaths ?? null,
+							cloneStrategy: r.cloneStrategy ?? null,
 							specialNotes: r.specialNotes ?? null
 						};
 					} else {
@@ -401,6 +403,7 @@ const createApp = (deps: {
 					branch: decoded.branch ?? 'main',
 					...(decoded.searchPath && { searchPath: decoded.searchPath }),
 					...(decoded.searchPaths && { searchPaths: decoded.searchPaths }),
+					...(decoded.cloneStrategy && { cloneStrategy: decoded.cloneStrategy }),
 					...(decoded.specialNotes && { specialNotes: decoded.specialNotes })
 				};
 				const added = await config.addResource(resource);

--- a/apps/server/src/resources/schema.ts
+++ b/apps/server/src/resources/schema.ts
@@ -157,6 +157,9 @@ const SpecialNotesSchema = z
 	)
 	.optional();
 
+const CloneStrategySchema = z.enum(['git', 'gitpick']).optional();
+
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Resource Schemas
 // ─────────────────────────────────────────────────────────────────────────────
@@ -168,6 +171,7 @@ export const GitResourceSchema = z.object({
 	branch: BranchNameSchema,
 	searchPath: OptionalSearchPathSchema,
 	searchPaths: SearchPathsSchema,
+	cloneStrategy: CloneStrategySchema,
 	specialNotes: SpecialNotesSchema
 });
 

--- a/apps/server/src/resources/service.ts
+++ b/apps/server/src/resources/service.ts
@@ -40,7 +40,8 @@ export namespace Resources {
 		repoSubPaths: normalizeSearchPaths(definition),
 		resourcesDirectoryPath: resourcesDirectory,
 		specialAgentInstructions: definition.specialNotes ?? '',
-		quiet
+		quiet,
+		cloneStrategy: definition.cloneStrategy
 	});
 
 	const definitionToLocalArgs = (definition: LocalResource): BtcaLocalResourceArgs => ({

--- a/apps/server/src/resources/types.ts
+++ b/apps/server/src/resources/types.ts
@@ -20,6 +20,7 @@ export type BtcaGitResourceArgs = {
 	readonly resourcesDirectoryPath: string;
 	readonly specialAgentInstructions: string;
 	readonly quiet: boolean;
+	readonly cloneStrategy?: 'git' | 'gitpick';
 };
 
 export type BtcaLocalResourceArgs = {

--- a/apps/web/src/routes/config/+page.svelte
+++ b/apps/web/src/routes/config/+page.svelte
@@ -231,6 +231,11 @@ Available resources: svelte, effect`;
 							<td class="py-2 pr-4">No</td>
 							<td class="py-2">Multiple subdirectories to search within the repo</td>
 						</tr>
+						<tr class="border-b border-[color:hsl(var(--bc-border))]">
+							<td class="py-2 pr-4"><code class="bc-inlineCode">cloneStrategy</code></td>
+							<td class="py-2 pr-4">No</td>
+							<td class="py-2">Clone strategy (git or gitpick)</td>
+						</tr>
 						<tr>
 							<td class="py-2 pr-4"><code class="bc-inlineCode">specialNotes</code></td>
 							<td class="py-2 pr-4">No</td>

--- a/apps/web/static/btca.schema.json
+++ b/apps/web/static/btca.schema.json
@@ -83,6 +83,11 @@
 						"type": "string"
 					}
 				},
+				"cloneStrategy": {
+					"type": "string",
+					"description": "Clone strategy to use (git or gitpick)",
+					"enum": ["git", "gitpick"]
+				},
 				"specialNotes": {
 					"type": "string",
 					"description": "Additional context or notes about this resource for the AI"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds optional `cloneStrategy` field supporting 'git' or 'gitpick' values to enable faster GitHub repository cloning across all interfaces (CLI, TUI, web, server)
- Implements gitpick-specific cloning logic with GitHub-only validation and search path restrictions, while improving error messages with stderr context
- Maintains backward compatibility by making `cloneStrategy` optional and defaulting to existing 'git' behavior when not specified

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `apps/server/src/resources/impls/git.ts` | Added gitpick cloning strategy with GitHub URL validation and search path restrictions; contains validation issues |
| `apps/cli/src/client/index.ts` | Added `cloneStrategy` field to client interface; creates validation mismatch with server restrictions |
| `apps/server/src/resources/schema.ts` | Added proper schema validation for `cloneStrategy` enum field as optional |

<h3>Confidence score: 3/5</h3>


- This PR introduces functional gitpick cloning but has validation gaps that could cause user experience issues
- Score reduced due to three key problems: overly permissive GitHub URL validation using simple string matching, no migration path for existing resources with search paths switching to gitpick, and client-server validation mismatch where client accepts configurations server rejects
- Pay close attention to `apps/server/src/resources/impls/git.ts` for URL validation logic and `apps/cli/src/client/index.ts` for alignment with server restrictions

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->