### PR TITLE
fix(cli): ensure config model command exits with 0

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -107,9 +107,7 @@ const modelCommand = new Command('model')
 			try {
 				const client = createClient(server.url);
 				const providers = await getProviders(client);
-				const provider = providers.all.find(
-					(p: { id: string }) => p.id === result.provider
-				);
+				const provider = providers.all.find((p: { id: string }) => p.id === result.provider);
 				if (!provider) {
 					console.warn(
 						`Warning: Provider "${result.provider}" is not available. ` +
@@ -136,6 +134,7 @@ const modelCommand = new Command('model')
 			}
 
 			server.stop();
+			process.exit(0);
 		} catch (error) {
 			console.error(formatError(error));
 			process.exit(1);


### PR DESCRIPTION
The config model command CLI didn't exit if it was successful

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added explicit `process.exit(0)` after successful model configuration to ensure the CLI properly terminates with exit code 0. Also reformatted the provider lookup for better readability.

- Fixed the model command to exit with status code 0 on success
- Minor formatting improvement to provider lookup logic

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The change correctly addresses the issue by adding an explicit exit call. The fix is simple and targeted, though there's a minor inconsistency with other commands in the same file that don't explicitly exit with 0
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/config.ts | Added explicit `process.exit(0)` after server stop on success path to ensure proper CLI exit; also reformatted provider lookup |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->