### PR TITLE
Exit after btca config updates

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -118,7 +118,7 @@ const modelCommand = new Command('model')
 				} else if (!providers.connected.includes(result.provider)) {
 					console.warn(
 						`Warning: Provider "${result.provider}" is not connected. ` +
-							'Run "opencode auth" to configure credentials.'
+							'Run "btca auth" or "opencode auth" to configure credentials.'
 					);
 				} else {
 					const modelIds = Object.keys(provider.models ?? {});
@@ -136,6 +136,7 @@ const modelCommand = new Command('model')
 			}
 
 			server.stop();
+			process.exit(0);
 		} catch (error) {
 			console.error(formatError(error));
 			process.exit(1);
@@ -185,6 +186,7 @@ const resourcesListCommand = new Command('list')
 			}
 
 			server.stop();
+			process.exit(0);
 		} catch (error) {
 			console.error(formatError(error));
 			process.exit(1);
@@ -267,6 +269,7 @@ const resourcesAddCommand = new Command('add')
 			}
 
 			server.stop();
+			process.exit(0);
 		} catch (error) {
 			console.error(formatError(error));
 			process.exit(1);
@@ -295,7 +298,7 @@ const resourcesRemoveCommand = new Command('remove')
 			if (resources.length === 0) {
 				console.log('No resources configured.');
 				server.stop();
-				return;
+				process.exit(0);
 			}
 
 			const names = resources.map((r) => r.name);
@@ -318,6 +321,7 @@ const resourcesRemoveCommand = new Command('remove')
 			console.log(`Removed resource: ${resourceName}`);
 
 			server.stop();
+			process.exit(0);
 		} catch (error) {
 			console.error(formatError(error));
 			process.exit(1);


### PR DESCRIPTION
## Summary
- exit cleanly after btca config model/resources commands complete

## Testing
- btca config model -p openai -m gpt-5.1-codex-mini

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds explicit `process.exit(0)` calls to ensure btca config commands terminate cleanly after successful completion
- Updates help message to reference both "btca auth" and "opencode auth" commands for improved user guidance

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/config.ts | Added process.exit(0) calls to config subcommands and updated auth warning message |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects simple, isolated changes that fix a clear UX issue without modifying core logic or breaking existing functionality
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->