### PR TITLE
fix(resources): add helpful error messages for invalid searchPath

### DIFF
--- a/ISSUE_IMPLEMENTATION_PLAN.md
+++ b/ISSUE_IMPLEMENTATION_PLAN.md
@@ -442,12 +442,12 @@ Should have been:
 
 #### Acceptance Criteria
 
-- [ ] Invalid searchPath throws clear error before querying
-- [ ] Error message includes the invalid path and resource name
-- [ ] Helpful hints detect common mistakes (GitHub URL patterns, etc.)
-- [ ] Suggested fix is actionable (shows correct path format)
-- [ ] Valid searchPaths continue to work as before
-- [ ] Collection creation fails fast with invalid paths
+- [x] Invalid searchPath throws clear error before querying
+- [x] Error message includes the invalid path and resource name
+- [x] Helpful hints detect common mistakes (GitHub URL patterns, etc.)
+- [x] Suggested fix is actionable (shows correct path format)
+- [x] Valid searchPaths continue to work as before
+- [x] Collection creation fails fast with invalid paths
 
 ---
 
@@ -1045,7 +1045,7 @@ Local file paths don't work correctly on Windows (e.g., `E:\GitHub\...`).
 | Issue                   | Effort | Impact | Priority Score | Status   |
 | ----------------------- | ------ | ------ | -------------- | -------- |
 | #99 (cleanup)           | Medium | High   | **High**       | DONE     |
-| #76 (searchPath)        | Medium | High   | **High**       | PLANNED  |
+| #76 (searchPath)        | Medium | High   | **High**       | DONE     |
 | #81 (.btca folder)      | Medium | Medium | **Medium**     | PLANNED  |
 | #96 (CSS scroll)        | Small  | Low    | **Low**        | PLANNED  |
 | #109 (gateway)          | Small  | High   | High           | DEFERRED |


### PR DESCRIPTION
Fixes https://github.com/davis7dotsh/better-context/issues/76

- Improve ensureSearchPathsExist to include resource name in error
- Add getSearchPathHint function to detect common mistakes:
  - GitHub URL-style paths (tree/branch/path, blob/branch/path)
  - Full URLs included in searchPath
  - Domain names in path
- Provide actionable hints showing the correct path format
- Include 'ls' command suggestion for discovering valid paths

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved error handling for invalid `searchPath` configurations in git resources by adding helpful, context-aware error messages.

- Added `getSearchPathHint()` function that detects common mistakes (GitHub URL patterns like `tree/branch/path`, full URLs, domain names)
- Enhanced `ensureSearchPathsExist()` to include resource name in error messages for better debugging
- Updated error messages to provide actionable hints with correct path format examples
- Marked issue #76 as DONE in `ISSUE_IMPLEMENTATION_PLAN.md`

**Note:** Plan file `ISSUE_IMPLEMENTATION_PLAN.md` was updated in this PR to track completion status.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused error handling improvements with no breaking changes
- The changes are well-scoped, improve user experience with better error messages, and don't modify any core logic. The new `getSearchPathHint` function only affects error messaging, and the additional `resourceName` parameter maintains backward compatibility at all call sites.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ISSUE_IMPLEMENTATION_PLAN.md | Updated checkboxes and status to mark issue #76 as DONE |
| apps/server/src/resources/impls/git.ts | Added `getSearchPathHint` helper and improved error messages with resource name context |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->