### PR TITLE
fix(web): add horizontal scrollbar to code blocks on homepage

### DIFF
--- a/ISSUE_IMPLEMENTATION_PLAN.md
+++ b/ISSUE_IMPLEMENTATION_PLAN.md
@@ -786,12 +786,12 @@ Code blocks on the btca.dev homepage are truncated horizontally without a scroll
 
 #### Acceptance Criteria
 
-- [ ] Code blocks show horizontal scrollbar when content overflows
-- [ ] Scrollbar is visible and usable
-- [ ] No content is cut off without indication
-- [ ] Page doesn't scroll horizontally (only code block)
-- [ ] Works across major browsers
-- [ ] Responsive across screen sizes
+- [x] Code blocks show horizontal scrollbar when content overflows
+- [x] Scrollbar is visible and usable
+- [x] No content is cut off without indication
+- [x] Page doesn't scroll horizontally (only code block)
+- [x] Works across major browsers
+- [x] Responsive across screen sizes
 
 ---
 
@@ -1047,7 +1047,7 @@ Local file paths don't work correctly on Windows (e.g., `E:\GitHub\...`).
 | #99 (cleanup)           | Medium | High   | **High**       | DONE     |
 | #76 (searchPath)        | Medium | High   | **High**       | DONE     |
 | #81 (.btca folder)      | Medium | Medium | **Medium**     | DONE     |
-| #96 (CSS scroll)        | Small  | Low    | **Low**        | PLANNED  |
+| #96 (CSS scroll)        | Small  | Low    | **Low**        | DONE     |
 | #109 (gateway)          | Small  | High   | High           | DEFERRED |
 | #105/#89 (Windows)      | Large  | High   | High           | DEFERRED |
 | #91 (sub-agent)         | Medium | Medium | Medium         | DEFERRED |

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -62,7 +62,7 @@
 					<div class="text-xs bc-muted">btca</div>
 				</div>
 
-				<div class="p-4">
+				<div class="overflow-x-auto p-4">
 					{#if shikiStore.highlighter}
 						{@html shikiStore.highlighter.codeToHtml(DEMO, {
 							theme: shikiTheme,

--- a/apps/web/src/routes/layout.css
+++ b/apps/web/src/routes/layout.css
@@ -576,6 +576,25 @@
 		border-radius: 0;
 		overflow: hidden;
 		position: relative;
+		max-width: 100%;
+	}
+
+	.bc-codeFrame pre {
+		overflow-x: auto;
+		scrollbar-width: thin;
+	}
+
+	.bc-codeFrame pre::-webkit-scrollbar {
+		height: 6px;
+	}
+
+	.bc-codeFrame pre::-webkit-scrollbar-thumb {
+		background-color: hsl(var(--bc-border));
+		border-radius: 3px;
+	}
+
+	.bc-codeFrame pre::-webkit-scrollbar-track {
+		background-color: transparent;
 	}
 
 	.bc-codeFrame::after {


### PR DESCRIPTION
Fixes https://github.com/davis7dotsh/better-context/issues/96

- Add overflow-x-auto to code block container on homepage
- Add max-width: 100% to .bc-codeFrame to constrain width
- Add overflow-x: auto to pre elements inside .bc-codeFrame
- Style scrollbar with thin width and themed colors
- Support both Firefox (scrollbar-width) and Webkit browsers

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully fixes horizontal overflow issues with code blocks on the homepage by adding `overflow-x-auto` to the container and styling scrollbars for a consistent look across browsers.

**Key changes:**
- Added `overflow-x-auto` to code block container in `+page.svelte:65`
- Added `max-width: 100%` and `overflow-x: auto` to `.bc-codeFrame pre` in global CSS
- Implemented custom scrollbar styling for both Firefox (`scrollbar-width: thin`) and Webkit browsers (`::-webkit-scrollbar-*`)
- Updated `ISSUE_IMPLEMENTATION_PLAN.md` to mark issue #96 as DONE

**Note:** The PR includes changes to `ISSUE_IMPLEMENTATION_PLAN.md`, a planning document that typically should not be committed to the repository.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped CSS additions that enable horizontal scrolling on code blocks. The global `.bc-codeFrame pre` styles apply to all code blocks site-wide, which is appropriate since other pages already use `overflow-x-auto` on their containers. The implementation includes cross-browser scrollbar styling and won't break existing functionality.
- Consider whether `ISSUE_IMPLEMENTATION_PLAN.md` should be committed or added to `.gitignore`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ISSUE_IMPLEMENTATION_PLAN.md | Checked off acceptance criteria and updated issue status to DONE |
| apps/web/src/routes/+page.svelte | Added overflow-x-auto to code block container div |
| apps/web/src/routes/layout.css | Added horizontal scroll styles to .bc-codeFrame pre elements with custom scrollbar styling |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->