### PR TITLE
fix: prefer opencode's specified port when defined in opencode.json

### DIFF
--- a/apps/server/src/agent/service.ts
+++ b/apps/server/src/agent/service.ts
@@ -266,7 +266,7 @@ export namespace Agent {
 			});
 
 			if (created) {
-				const baseUrl = `http://localhost:${port}`;
+				const baseUrl = created.server?.url ?? `http://localhost:${port}`;
 				return {
 					client: createOpencodeClient({ baseUrl, directory: args.collectionPath }),
 					server: created.server,


### PR DESCRIPTION
btca CLI was failing when I had a custom port specified in my opencode.json file. Switched to using the returned url instead of the generated one. Found and fixed with codex.

#### Codex's assessment:

Issue: btca was always building baseUrl from its random port, even if
OpenCode actually bound to a different port from your config. That makes
the client talk to the wrong port → session create fails.

Change: use the real URL from createOpencode() (created.server.url) as
the primary source. Only if the SDK doesn’t provide a URL do we fall back
to http://localhost:${port}. So it’s “prefer actual server URL”, not
“fallback to actual”.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed a bug where `btca` CLI failed when a custom port was specified in `opencode.json`. The fix uses the actual URL returned by the OpenCode SDK (`created.server?.url`) instead of always constructing it from the random port, with fallback to the constructed URL if the SDK doesn't provide one.

- Changed `baseUrl` construction on line 269 to prefer `created.server?.url` over `http://localhost:${port}`
- This ensures the client connects to the correct port when OpenCode binds to a port from config instead of the random port passed to `createOpencode()`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line fix that improves robustness by preferring the actual server URL from the SDK over a constructed one. It maintains backward compatibility with the fallback to the constructed URL. The fix addresses a real bug where custom ports from config were ignored, and the solution aligns with the SDK's design (server.url is already used elsewhere in the codebase).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/server/src/agent/service.ts | Fixed port mismatch by preferring actual server URL from OpenCode SDK over constructed localhost URL |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->