### PR TITLE
add cursor rules setup command

### DIFF
--- a/apps/web/src/routes/cli/+page.svelte
+++ b/apps/web/src/routes/cli/+page.svelte
@@ -178,7 +178,7 @@
 								></pre>
 						{/if}
 					</div>
-					<CopyButton text={CURSOR_RULE_CMD} label="Copy quick start command" />
+					<CopyButton text={CURSOR_RULE_CMD} label="Copy Cursor rule command" />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Add a "Add Cursor rules" step with copyable command on CLI page

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new "Add Cursor rules" section to the CLI page with a command to download the Better Context rule file into the `.cursor/rules` directory. The implementation follows existing UI patterns and includes proper syntax highlighting, copy functionality, and descriptive text. The previous feedback about the button label has been addressed - it now correctly says "Copy Cursor rule command".

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and follow existing patterns. The new section is additive (doesn't modify existing functionality), uses consistent styling with other sections, properly integrates with the existing Shiki syntax highlighting, and includes proper copy functionality. The command itself is well-formed and targets a valid endpoint that serves the rule file.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/cli/+page.svelte | Added new "Add Cursor rules" section with command to download rule file. Changes are clean, consistent with existing patterns, and the previous label issue has been fixed. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->