### PR TITLE
fix: Prevent hover flicker loop on buttons with translateY

### DIFF
--- a/apps/web/src/routes/layout.css
+++ b/apps/web/src/routes/layout.css
@@ -189,7 +189,19 @@
 		font-size: 13px;
 		letter-spacing: 0.02em;
 		background: transparent;
-		transition: background 120ms ease;
+		transition:
+			background 120ms ease,
+			transform 120ms ease;
+		position: relative;
+	}
+
+	.bc-navLink::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: -4px;
+		height: 4px;
 	}
 
 	.bc-navLink:hover {
@@ -209,7 +221,18 @@
 		text-decoration: none;
 		transition:
 			background 120ms ease,
-			border-color 120ms ease;
+			border-color 120ms ease,
+			transform 120ms ease;
+		position: relative;
+	}
+
+	.bc-chip::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: -4px;
+		height: 4px;
 	}
 
 	.bc-chip:hover {
@@ -373,6 +396,16 @@
 			transform 220ms ease,
 			border-color 220ms ease,
 			background 220ms ease;
+		position: relative;
+	}
+
+	.bc-cardHover::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: -6px;
+		height: 6px;
 	}
 
 	.bc-cardHover:hover {
@@ -446,7 +479,18 @@
 		color: hsl(var(--bc-fg));
 		transition:
 			background 120ms ease,
-			border-color 120ms ease;
+			border-color 120ms ease,
+			transform 120ms ease;
+		position: relative;
+	}
+
+	.bc-iconBtn::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: -4px;
+		height: 4px;
 	}
 
 	.bc-iconBtn:hover {


### PR DESCRIPTION
Fixes #136 

Adds invisible `::after` pseudo-elements to buttons and cards that lift on hover. This extends the hit area downwards to cover the space vacated by the element when it translates up

![hover_issue_fix](https://github.com/user-attachments/assets/8b428da2-8de8-438b-bde0-ac3ac77aa9b4)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added invisible `::after` pseudo-elements to `.bc-navLink`, `.bc-chip`, `.bc-cardHover`, and `.bc-iconBtn` classes to fix hover flicker issue.

The fix extends the clickable hit area below these elements to cover the gap created when they translate upward on hover. This prevents the infinite flicker loop that occurred when the cursor was in the vacated space.

**Changes:**
- Added `position: relative` to parent elements
- Added `transform` to transition properties for smooth animation
- Created invisible `::after` pseudo-elements positioned below each element (4-6px depending on translateY distance)

The implementation is clean and follows a consistent pattern across all affected classes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is focused, well-implemented, and addresses a specific UX issue without modifying existing functionality or breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/layout.css | Added invisible `::after` pseudo-elements to extend hit areas for elements with hover translateY effects, preventing flicker loop |

</details>



<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->