### PR TITLE
local mcp endpoint

### DIFF
--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -1,0 +1,102 @@
+import { Command } from 'commander';
+import { bold, dim, red } from '../lib/utils/colors.ts';
+
+type McpAgent = 'opencode' | 'claude' | 'cursor';
+
+type McpConfig =
+	| {
+			mcpServers: Record<
+				string,
+				{
+					url: string;
+					headers?: Record<string, string>;
+				}
+			>;
+	  }
+	| string;
+
+function getMcpConfig(agent: McpAgent, url: string, token?: string): McpConfig {
+	const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+
+	switch (agent) {
+		case 'claude': {
+			// Claude Code supports adding MCP servers via CLI.
+			// (User can also copy/paste JSON manually depending on their setup.)
+			const headerArgs = token ? ` --header "Authorization: Bearer ${token}"` : '';
+			return `claude mcp add better-context --url ${url}${headerArgs}`;
+		}
+		case 'cursor': {
+			return {
+				mcpServers: {
+					'better-context': {
+						url,
+						...(headers ? { headers } : {})
+					}
+				}
+			};
+		}
+		case 'opencode': {
+			return {
+				mcpServers: {
+					'better-context': {
+						url,
+						...(headers ? { headers } : {})
+					}
+				}
+			};
+		}
+	}
+}
+
+function getMcpInstructions(agent: McpAgent): string {
+	switch (agent) {
+		case 'opencode':
+			return `Add this to your ${bold('opencode.json')} file:`;
+		case 'claude':
+			return `Run this command to add the MCP server:`;
+		case 'cursor':
+			return `Add this to your ${bold('.cursor/mcp.json')} file:`;
+	}
+}
+
+export const mcpCommand = new Command('mcp')
+	.description('Output MCP configuration for local btca server (MCP over HTTP)')
+	.argument('[agent]', 'Agent type: opencode, claude, or cursor')
+	.option('-p, --port <port>', 'Local btca server port (default: 8080)', '8080')
+	.option('--token <token>', 'Optional bearer token required by the MCP endpoint')
+	.action(async (agent?: string, options?: { port?: string; token?: string }) => {
+		const port = options?.port ? parseInt(options.port, 10) : 8080;
+		const token = options?.token;
+
+		let selectedAgent: McpAgent;
+		if (agent) {
+			const normalized = agent.toLowerCase();
+			if (normalized !== 'opencode' && normalized !== 'claude' && normalized !== 'cursor') {
+				console.error(red(`Invalid agent: ${agent}`));
+				console.error('Valid options: opencode, claude, cursor');
+				process.exit(1);
+			}
+			selectedAgent = normalized as McpAgent;
+		} else {
+			// Default to Cursor since it's a common MCP consumer.
+			selectedAgent = 'cursor';
+		}
+
+		const url = `http://localhost:${port}/mcp`;
+		const config = getMcpConfig(selectedAgent, url, token);
+		const instructions = getMcpInstructions(selectedAgent);
+
+		console.log(`\n${dim('Local MCP server:')} ${bold(url)}`);
+		console.log(`${dim('Make sure the server is running with:')} ${bold('btca serve --mcp')}`);
+		if (token) {
+			console.log(`${dim('Token auth enabled (Authorization: Bearer …)')}`);
+		}
+
+		console.log(`\n${instructions}\n`);
+		if (typeof config === 'string') {
+			console.log(config);
+		} else {
+			console.log(JSON.stringify(config, null, 2));
+		}
+		console.log('');
+	});

--- a/apps/cli/src/commands/serve.ts
+++ b/apps/cli/src/commands/serve.ts
@@ -22,12 +22,18 @@ function formatError(error: unknown): string {
 export const serveCommand = new Command('serve')
 	.description('Start the btca server and listen for requests')
 	.option('-p, --port <port>', 'Port to listen on (default: 8080)')
-	.action(async (options: { port?: string }) => {
+	.option('--mcp', 'Enable MCP (Model Context Protocol) endpoint at /mcp')
+	.option('--mcp-token <token>', 'Require Bearer token for the /mcp endpoint')
+	.action(async (options: { port?: string; mcp?: boolean; mcpToken?: string }) => {
 		const port = options.port ? parseInt(options.port, 10) : DEFAULT_PORT;
 
 		try {
 			console.log(`Starting btca server on port ${port}...`);
-			const server = await startServer({ port });
+			const server = await startServer({
+				port,
+				enableMcp: options.mcp ?? false,
+				mcpToken: options.mcpToken
+			});
 			console.log(`btca server running at ${server.url}`);
 			console.log('Press Ctrl+C to stop');
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,7 @@ import { initCommand } from './commands/init.ts';
 import { removeCommand } from './commands/remove.ts';
 import { remoteCommand } from './commands/remote.ts';
 import { serveCommand } from './commands/serve.ts';
+import { mcpCommand } from './commands/mcp.ts';
 import { launchTui } from './commands/tui.ts';
 import { launchRepl } from './commands/repl.ts';
 import packageJson from '../package.json';
@@ -43,6 +44,9 @@ program.addCommand(initCommand);
 // Utility commands
 program.addCommand(clearCommand);
 program.addCommand(serveCommand);
+
+// Local MCP helper command
+program.addCommand(mcpCommand);
 
 // Remote mode commands
 program.addCommand(remoteCommand);

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -72,6 +72,9 @@
 		"hono": "^4.7.11",
 		"just-bash": "^2.7.0",
 		"opencode-ai": "^1.1.36",
+		"tmcp": "^1.19.0",
+		"@tmcp/transport-http": "^0.8.4",
+		"@tmcp/adapter-zod": "^0.1.7",
 		"zod": "^3.25.76"
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -75,10 +75,13 @@
         "@ai-sdk/xai": "^3.0.34",
         "@btca/shared": "workspace:*",
         "@opencode-ai/sdk": "^1.1.28",
+        "@tmcp/adapter-zod": "^0.1.7",
+        "@tmcp/transport-http": "^0.8.4",
         "ai": "^6.0.49",
         "hono": "^4.7.11",
         "just-bash": "^2.7.0",
         "opencode-ai": "^1.1.36",
+        "tmcp": "^1.19.0",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -2558,6 +2561,8 @@
 
     "btca-sandbox/@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
+    "btca-server/@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+
     "btca-server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "chrome-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -2749,6 +2754,8 @@
     "@solana/wallet-standard-wallet-adapter-base/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "btca-sandbox/@types/bun/bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+
+    "btca-server/@types/bun/bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "chrome-launcher/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 


### PR DESCRIPTION
chore: update bun.lock
:wq
:wq

feat: local MCP endpoint

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds local MCP (Model Context Protocol) endpoint support to btca, allowing AI agents like Claude, Cursor, and OpenCode to interact with the btca server via HTTP.

**Major changes:**
- New `/mcp` endpoint in the server with optional Bearer token authentication
- Three MCP tools exposed: `listResources`, `ask`, and `addResource`
- New CLI command `btca mcp` to generate configuration for different agents
- Added `--mcp` and `--mcp-token` flags to `btca serve` command
- New dependencies: `tmcp`, `@tmcp/transport-http`, `@tmcp/adapter-zod`

**Issues found:**
- The MCP `addResource` tool bypasses validation schemas used by REST API endpoints, creating inconsistent security validation between MCP and REST interfaces
- The MCP `askSchema` doesn't enforce the same length/size limits as the REST API's `QuestionRequestSchema`

<h3>Confidence Score: 3/5</h3>

- safe to merge with validation gaps that should be addressed soon
- the feature works and adds useful functionality, but has validation inconsistencies between MCP and REST endpoints that could allow bypassing security checks. the existing REST endpoints have comprehensive validation (resource names, URLs, branch names, etc.) that the MCP tools don't fully replicate
- apps/server/src/index.ts - validation gaps in MCP endpoint implementation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/server/src/index.ts | adds MCP endpoint with authentication, exposes listResources, ask, and addResource tools, but lacks proper validation on MCP inputs |
| apps/cli/src/commands/mcp.ts | new command to generate MCP config for different agents (claude, cursor, opencode) |
| apps/cli/src/commands/serve.ts | added `--mcp` and `--mcp-token` flags to enable MCP endpoint |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->