### PR TITLE
fix(cli): add OAuth copy-url fallback when browser open fails

### DIFF
--- a/apps/cli/src/tui/components/connect-wizard.tsx
+++ b/apps/cli/src/tui/components/connect-wizard.tsx
@@ -17,6 +17,7 @@ import { useMessagesContext } from '../context/messages-context.tsx';
 import { useConfigContext } from '../context/config-context.tsx';
 import { services } from '../services.ts';
 import { formatError } from '../lib/format-error.ts';
+import { copyToClipboard } from '../clipboard.ts';
 import { loginCopilotOAuth } from '../../lib/copilot-oauth.ts';
 import { loginOpenAIOAuth, saveProviderApiKey } from '../../lib/opencode-oauth.ts';
 import {
@@ -75,6 +76,7 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 	const [error, setError] = createSignal<string | null>(null);
 	const [statusMessage, setStatusMessage] = createSignal('');
 	const [busy, setBusy] = createSignal(false);
+	const [oauthFallbackUrl, setOauthFallbackUrl] = createSignal<string | null>(null);
 
 	const customModelOption: ModelOption = {
 		id: '__custom__',
@@ -87,6 +89,9 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 	const setStepSafe = (nextStep: ConnectStep) => {
 		setError(null);
 		setStatusMessage('');
+		if (nextStep !== 'auth') {
+			setOauthFallbackUrl(null);
+		}
 		setStep(nextStep);
 	};
 
@@ -126,6 +131,9 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 			return 'Loading providers...';
 		}
 		if (step() === 'auth') {
+			if (oauthFallbackUrl()) {
+				return 'Browser auto-open failed. Press c to copy the URL and paste it manually.';
+			}
 			return 'Complete authentication in the browser or terminal.';
 		}
 		if (step() === 'api-key') {
@@ -243,7 +251,13 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 		setStepSafe('auth');
 		setBusy(true);
 		setStatusMessage('Starting OpenAI OAuth flow...');
-		const result = await loginOpenAIOAuth();
+		const result = await loginOpenAIOAuth({
+			continueOnBrowserOpenFailure: true,
+			onBrowserOpenFailure: (url) => {
+				setOauthFallbackUrl(url);
+				setStatusMessage('Could not auto-open browser. Press c to copy authorization URL.');
+			}
+		});
 		setBusy(false);
 
 		if (!result.ok) {
@@ -471,6 +485,21 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 			return;
 		}
 
+		if (currentStep === 'auth' && key.name === 'c' && !key.ctrl) {
+			const url = oauthFallbackUrl();
+			if (!url) return;
+			void Result.tryPromise(() => copyToClipboard(url)).then((copyResult) => {
+				if (copyResult.isErr()) {
+					const message = formatError(copyResult.error);
+					setError(message);
+					messages.addSystemMessage(`Error: ${message}`);
+					return;
+				}
+				setStatusMessage('Authorization URL copied. Paste it in your browser to continue.');
+			});
+			return;
+		}
+
 		if (currentStep === 'provider') {
 			switch (key.name) {
 				case 'up':
@@ -627,6 +656,9 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 			</Show>
 			<Show when={statusMessage().length > 0}>
 				<text fg={colors.textMuted} content={` ${statusMessage()}`} />
+			</Show>
+			<Show when={step() === 'auth' && oauthFallbackUrl()}>
+				<text fg={colors.textSubtle} content={` Authorization URL: ${oauthFallbackUrl()}`} />
 			</Show>
 			<Show when={error()}>
 				<text fg={colors.error} content={` ${error()}`} />


### PR DESCRIPTION
## Summary

On Windows, OAuth browser auto-open can fail on some setups, which leaves users stuck in the TUI flow.

This PR adds a manual fallback path so users can copy the authorization URL and continue authentication without restarting.

## Changes

- Adds browser-open failure handling to OpenAI OAuth login:
  - Captures non-zero exits from platform open commands (`open`, `cmd /c start`, `xdg-open`).
  - Exposes optional callbacks for auth URL and browser-open failure.
  - Continues OAuth flow by default when browser auto-open fails.
- Updates Connect Wizard auth step:
  - Stores fallback OAuth URL when browser open fails.
  - Shows clear status guidance in auth step.
  - Adds `c` key shortcut in auth step to copy URL to clipboard.
  - Shows success/error feedback for clipboard copy.

## Why

This keeps OAuth usable on Windows environments where browser launch is unreliable, while preserving current behavior on systems where browser open works.

## Validation

- `bun run --cwd apps/cli check`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the CLI OAuth flow by detecting failures to auto-open the authorization URL (notably on Windows) and exposing hooks so the TUI can present a manual fallback.

On the library side (`apps/cli/src/lib/opencode-oauth.ts`), the OAuth login now reports the auth URL and browser-open failures via optional callbacks while continuing the underlying OAuth polling/verification.

On the TUI side (`apps/cli/src/tui/components/connect-wizard.tsx`), the connect wizard stores the fallback URL, shows user guidance, and adds a `c` shortcut to copy the URL to the clipboard.

One issue to address before merge: the new `c` key handler can still fire when there is no fallback URL (browser open succeeded), which can crash or behave incorrectly when attempting to copy a null URL.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a user-facing crash path in the TUI auth step that should be fixed first.
- Core OAuth fallback behavior in the library looks consistent with existing flow (continue on open failure), but the connect wizard’s new clipboard shortcut does not guard against a missing fallback URL, which can break the auth step even when auto-open works.
- apps/cli/src/tui/components/connect-wizard.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/lib/opencode-oauth.ts | Adds optional callbacks to surface the OAuth authorization URL and handle browser-open failures, while continuing the OAuth flow when auto-open fails. |
| apps/cli/src/tui/components/connect-wizard.tsx | Adds TUI fallback UX for OAuth URL copying, but the new auth-step key handler can crash when no fallback URL is available. |

</details>



<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->