### PR TITLE
feat: allow @ in branch field for monorepo tag support

### DIFF
--- a/apps/server/src/resources/impls/git.ts
+++ b/apps/server/src/resources/impls/git.ts
@@ -239,7 +239,7 @@ const gitClone = async (args: {
 	if (!branchValidation.success) {
 		throw new ResourceError({
 			message: branchValidation.error,
-			hint: 'Branch names can only contain letters, numbers, hyphens, underscores, dots, and forward slashes.',
+			hint: 'Branch names can only contain letters, numbers, hyphens, underscores, dots, forward slashes, and @ symbols.',
 			cause: new Error('Branch validation failed')
 		});
 	}

--- a/apps/server/src/resources/schema.ts
+++ b/apps/server/src/resources/schema.ts
@@ -17,7 +17,7 @@ const RESOURCE_NAME_REGEX = /^@?[a-zA-Z0-9][a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0
  * Branch name: alphanumeric, forward slashes, dots, underscores, and hyphens.
  * Must not start with hyphen to prevent git option injection.
  */
-const BRANCH_NAME_REGEX = /^[a-zA-Z0-9/_.-]+$/;
+const BRANCH_NAME_REGEX = /^[a-zA-Z0-9/_.\-@]+$/;
 
 const parseUrl = (value: string) =>
 	Result.try(() => new URL(value)).match({
@@ -99,7 +99,7 @@ const BranchNameSchema = z
 	.max(LIMITS.BRANCH_NAME_MAX, `Branch name too long (max ${LIMITS.BRANCH_NAME_MAX} chars)`)
 	.regex(
 		BRANCH_NAME_REGEX,
-		'Branch name must contain only alphanumeric characters, forward slashes, dots, underscores, and hyphens'
+		'Branch name must contain only alphanumeric characters, forward slashes, dots, underscores, hyphens, and @ symbols'
 	)
 	.refine((branch) => !branch.startsWith('-'), {
 		message: "Branch name must not start with '-' to prevent git option injection"

--- a/apps/server/src/validation/index.ts
+++ b/apps/server/src/validation/index.ts
@@ -23,7 +23,7 @@ const RESOURCE_NAME_REGEX = /^@?[a-zA-Z0-9][a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0
  * Branch name: alphanumeric, forward slashes, dots, underscores, and hyphens.
  * Must not start with hyphen to prevent git option injection.
  */
-const BRANCH_NAME_REGEX = /^[a-zA-Z0-9/_.-]+$/;
+const BRANCH_NAME_REGEX = /^[a-zA-Z0-9/_.\-@]+$/;
 
 /**
  * Provider/Model names: letters, numbers, dots, underscores, plus, hyphens, forward slashes, colons.
@@ -152,7 +152,7 @@ export const validateBranchName = (branch: string): ValidationResult => {
 
 	if (!BRANCH_NAME_REGEX.test(branch)) {
 		return fail(
-			`Invalid branch name: "${branch}". Must contain only alphanumeric characters, forward slashes, dots, underscores, and hyphens`
+			`Invalid branch name: "${branch}". Must contain only alphanumeric characters, forward slashes, dots, underscores, hyphens, and @ symbols`
 		);
 	}
 

--- a/apps/web/static/btca.schema.json
+++ b/apps/web/static/btca.schema.json
@@ -87,7 +87,8 @@
 				},
 				"branch": {
 					"type": "string",
-					"description": "Git branch to use",
+					"description": "Git branch, tag, or ref to use (supports monorepo-style tags like @scope/pkg@version)",
+					"pattern": "^[a-zA-Z0-9/_\\.\\-@]+$",
 					"default": "main"
 				},
 				"searchPath": {


### PR DESCRIPTION
Hi, 

couldn't find a way to get btca to work with monorepo-style git tags like `@chakra-ui/react@2.8.2` Just a small update to allow them in the branch names

## Summary

- Adds `@` to the branch name validation regex, enabling monorepo-style git tags like `@chakra-ui/react@2.8.2` in the `branch` field
- Updates error messages across schema, validation, and git clone hint to mention `@` symbols
- Adds branch validation tests (schema-level and integration-level)
- Adds `pattern` to the JSON schema `branch` field

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added support for `@` symbols in git branch names to enable monorepo-style tags like ``@chakra-ui/react@2.8.2``.

**Changes:**
- Modified `BRANCH_NAME_REGEX` in both `schema.ts` and `validation/index.ts` to include `@` in allowed characters
- Updated error messages and hints across validation, schema, and git clone logic to mention `@` symbols
- Added pattern validation to JSON schema for branch field
- Added comprehensive test coverage for branch validation including monorepo tags, version tags, standard branches, and rejection cases

**No plan markdown files found in this PR.**

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are narrow in scope, well-tested, and maintain security checks. The regex modification adds `@` to allowed characters while preserving critical security validations (no leading hyphens, character restrictions). Comprehensive test coverage validates both the new functionality and rejection of dangerous patterns. No breaking changes to existing features.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/server/src/resources/schema.ts | Updated BRANCH_NAME_REGEX to allow `@` symbols and updated error message to mention `@` symbols |
| apps/server/src/validation/index.ts | Updated BRANCH_NAME_REGEX to allow `@` symbols and updated error message in validateBranchName |
| apps/server/src/resources/impls/git.ts | Updated hint message in gitClone to mention `@` symbols as allowed characters |
| apps/server/src/resources/impls/git.test.ts | Added comprehensive branch validation tests including monorepo-style tags with `@` symbols, rejection tests for invalid patterns |
| apps/web/static/btca.schema.json | Added pattern validation and updated description to mention monorepo-style tags for branch field |

</details>



<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->