### PR TITLE
added minimax provider

### DIFF
--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -170,6 +170,7 @@ async function runBtcaAuth(providerId: string): Promise<boolean> {
 		providerId === 'opencode' ||
 		providerId === 'openrouter' ||
 		providerId === 'anthropic' ||
+		providerId === 'minimax' ||
 		providerId === 'google'
 	) {
 		const setup = PROVIDER_SETUP_LINKS[providerId];
@@ -210,7 +211,7 @@ export const connectCommand = new Command('connect')
 	.option('-g, --global', 'Save to global config instead of project config')
 	.option(
 		'-p, --provider <id>',
-		'Provider ID (opencode, openrouter, openai, openai-compat, google, anthropic, github-copilot)'
+		'Provider ID (opencode, openrouter, openai, openai-compat, google, anthropic, github-copilot, minimax)'
 	)
 	.option('-m, --model <id>', 'Model ID (e.g., "claude-haiku-4-5")')
 	.action(async (options: { global?: boolean; provider?: string; model?: string }, command) => {

--- a/apps/cli/src/connect/constants.ts
+++ b/apps/cli/src/connect/constants.ts
@@ -23,7 +23,8 @@ export const CURATED_MODELS: Record<string, { id: string; label: string }[]> = {
 		{ id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5 (2025-10-01)' },
 		{ id: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5 (2025-09-29)' }
 	],
-	google: [{ id: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' }]
+	google: [{ id: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' }],
+	minimax: [{ id: 'MiniMax-M2.1', label: 'MiniMax M2.1' }]
 };
 
 export const PROVIDER_INFO: Record<string, { label: string; requiresAuth: boolean }> = {
@@ -32,6 +33,7 @@ export const PROVIDER_INFO: Record<string, { label: string; requiresAuth: boolea
 	anthropic: { label: 'Anthropic (Claude)', requiresAuth: true },
 	openai: { label: 'OpenAI (GPT)', requiresAuth: true },
 	'openai-compat': { label: 'OpenAI Compatible', requiresAuth: false },
+	minimax: { label: 'MiniMax', requiresAuth: true },
 	google: { label: 'Google (Gemini)', requiresAuth: true },
 	openrouter: { label: 'OpenRouter', requiresAuth: true }
 };
@@ -39,6 +41,7 @@ export const PROVIDER_INFO: Record<string, { label: string; requiresAuth: boolea
 export const PROVIDER_AUTH_GUIDANCE: Record<string, string> = {
 	'github-copilot': 'GitHub Copilot uses device flow OAuth: follow the browser prompt.',
 	openai: 'OpenAI requires OAuth: btca will open a browser to sign in.',
+	minimax: 'MiniMax uses API keys: paste your MiniMax API key to continue.',
 	'openai-compat': 'Enter base URL, name, and model ID. API key is optional.',
 	anthropic: 'Anthropic uses API keys: paste your API key to continue.',
 	google: 'Google uses API keys: paste your API key to continue.',
@@ -62,11 +65,16 @@ export const PROVIDER_MODEL_DOCS: Record<string, { label: string; url: string }>
 	'github-copilot': {
 		label: 'Model docs',
 		url: 'https://docs.github.com/en/rest/models?apiVersion=2022-11-28'
-	}
+	},
+	minimax: { label: 'Model docs', url: 'https://platform.minimax.io/docs/guides/text-generation' }
 };
 
 export const PROVIDER_SETUP_LINKS: Record<string, { label: string; url: string }> = {
 	opencode: { label: 'Get OpenCode Zen API key', url: 'https://opencode.ai/zen' },
+	minimax: {
+		label: 'Get MiniMax API key',
+		url: 'https://platform.minimax.io/user-center/basic-information'
+	},
 	openrouter: { label: 'Get OpenRouter API key', url: 'https://openrouter.ai/models' },
 	google: { label: 'Get Google API key', url: 'https://aistudio.google.com/api-keys' },
 	anthropic: { label: 'Get Anthropic API key', url: 'https://platform.claude.com/dashboard' }

--- a/apps/cli/src/tui/components/connect-wizard.tsx
+++ b/apps/cli/src/tui/components/connect-wizard.tsx
@@ -288,6 +288,7 @@ export const ConnectWizard: Component<ConnectWizardProps> = (props) => {
 			providerId === 'opencode' ||
 			providerId === 'openrouter' ||
 			providerId === 'anthropic' ||
+			providerId === 'minimax' ||
 			providerId === 'google'
 		) {
 			setStepSafe('api-key');

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -50,11 +50,13 @@ Supported providers:
 - `openai-compat` — optional API key (requires baseURL + name in config)
 - `anthropic` — API key
 - `google` — API key or OAuth
+- `minimax` — API key
 
 Environment variable overrides:
 
 - `OPENCODE_API_KEY` (for provider `opencode`)
 - `OPENROUTER_API_KEY` (for provider `openrouter`)
+- `MINIMAX_API_KEY` (for provider `minimax`)
 
 ### 2.2 CLI connect/disconnect
 
@@ -62,7 +64,7 @@ Environment variable overrides:
 
 - If provider is `openai`, runs local OAuth flow (PKCE) and writes tokens into OpenCode auth.
 - If provider is `openai-compat`, prompts for base URL, provider name, model ID, and optional API key.
-- If provider is `opencode`, `openrouter`, `anthropic`, or `google`, prompts for API key and writes into OpenCode auth.
+- If provider is `opencode`, `openrouter`, `anthropic`, `google`, or `minimax`, prompts for API key and writes into OpenCode auth.
 - If provider is not handled directly, falls back to `opencode auth --provider <provider>`.
 
 **OpenAI-compatible provider inputs (and why):**

--- a/apps/docs/guides/authentication.mdx
+++ b/apps/docs/guides/authentication.mdx
@@ -19,11 +19,13 @@ Supported providers:
 - `openai-compat` (optional API key)
 - `anthropic` (API key)
 - `google` (API key or OAuth)
+- `minimax` (API key)
 
 Environment variable overrides:
 
 - `OPENCODE_API_KEY` (for provider `opencode`)
 - `OPENROUTER_API_KEY` (for provider `openrouter`)
+- `MINIMAX_API_KEY` (for provider `minimax`)
 
 ### Connect or disconnect
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -61,6 +61,7 @@
 		"hono": "^4.7.11",
 		"just-bash": "^2.7.0",
 		"opencode-ai": "^1.1.36",
+		"vercel-minimax-ai-provider": "^0.0.2",
 		"zod": "^3.25.76"
 	}
 }

--- a/apps/server/src/providers/auth.ts
+++ b/apps/server/src/providers/auth.ts
@@ -27,7 +27,8 @@ export namespace Auth {
 		openai: ['oauth'],
 		'openai-compat': ['api'],
 		anthropic: ['api'],
-		google: ['api', 'oauth']
+		google: ['api', 'oauth'],
+		minimax: ['api']
 	};
 
 	const readEnv = (key: string) => {
@@ -38,6 +39,7 @@ export namespace Auth {
 	const getEnvApiKey = (providerId: string) => {
 		if (providerId === 'openrouter') return readEnv('OPENROUTER_API_KEY');
 		if (providerId === 'opencode') return readEnv('OPENCODE_API_KEY');
+		if (providerId === 'minimax') return readEnv('MINIMAX_API_KEY');
 		return undefined;
 	};
 
@@ -175,6 +177,8 @@ export namespace Auth {
 				return 'Set OPENROUTER_API_KEY or run "opencode auth --provider openrouter".';
 			case 'opencode':
 				return 'Set OPENCODE_API_KEY or run "opencode auth --provider opencode".';
+			case 'minimax':
+				return 'Set MINIMAX_API_KEY or run "opencode auth --provider minimax". Get your API key at https://platform.minimax.io/user-center/basic-information.';
 			default:
 				return 'Run "opencode auth --provider <provider>" to configure credentials.';
 		}

--- a/apps/server/src/providers/minimax.ts
+++ b/apps/server/src/providers/minimax.ts
@@ -1,0 +1,28 @@
+import { createMinimax } from 'vercel-minimax-ai-provider';
+
+const DEFAULT_BASE_URL = 'https://api.minimax.io/anthropic/v1';
+
+const readEnv = (key: string) => {
+	const value = process.env[key];
+	return value && value.trim().length > 0 ? value.trim() : undefined;
+};
+
+export const MINIMAX_MODELS = ['MiniMax-M2.1'] as const;
+
+export type MinimaxModel = (typeof MINIMAX_MODELS)[number];
+
+export function createMinimaxProvider(
+	options: {
+		apiKey?: string;
+		baseURL?: string;
+		headers?: Record<string, string>;
+	} = {}
+) {
+	const provider = createMinimax({
+		apiKey: options.apiKey ?? readEnv('MINIMAX_API_KEY'),
+		baseURL: options.baseURL ?? DEFAULT_BASE_URL,
+		headers: options.headers
+	});
+
+	return (modelId: string) => provider(modelId);
+}

--- a/apps/server/src/providers/registry.ts
+++ b/apps/server/src/providers/registry.ts
@@ -10,6 +10,7 @@ import { createOpenCodeZen } from './opencode.ts';
 import { createOpenAICodex } from './openai.ts';
 import { createOpenAICompat } from './openai-compat.ts';
 import { createOpenRouter } from './openrouter.ts';
+import { createMinimaxProvider } from './minimax.ts';
 
 // Type for provider factory options
 export type ProviderOptions = {
@@ -46,7 +47,10 @@ export const PROVIDER_REGISTRY: Record<string, ProviderFactory> = {
 	google: createGoogleGenerativeAI as ProviderFactory,
 
 	// OpenRouter (OpenAI-compatible gateway)
-	openrouter: createOpenRouter as ProviderFactory
+	openrouter: createOpenRouter as ProviderFactory,
+
+	// MiniMax (Anthropic-compatible gateway)
+	minimax: createMinimaxProvider as ProviderFactory
 };
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,7 @@
         "hono": "^4.7.11",
         "just-bash": "^2.7.0",
         "opencode-ai": "^1.1.36",
+        "vercel-minimax-ai-provider": "^0.0.2",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -2256,6 +2257,8 @@
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
+    "vercel-minimax-ai-provider": ["vercel-minimax-ai-provider@0.0.2", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.6", "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.4" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-h9QzLL7RBmOreqWfr2fcoFVNTJgusENJVagVm8vAi+DBfd+1t+sVJZ/hAhKrtuCKCrm33BlOSWVdJehQFju5jQ=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -2672,6 +2675,12 @@
 
     "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.6", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Ns5OOPHXbODzitvqCySnAFZCAm9ldpx+fdbC0c/f9QwX5b4MQtQJIQ0xZyKm+tB/ynBoeV6zhtyWDXjYeVEWIw=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.4", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg=="],
+
     "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -2823,6 +2832,10 @@
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@3.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg=="],
+
+    "vercel-minimax-ai-provider/@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.3", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Vo2p61dDld8Dy/O66zKQpE4nqHojiEEYEjZcSbICjE7h8Z6QmHzBfd+ss/paIDdyXyS0yHmC1GoRYYKo89cqZQ=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `minimax` provider across the stack:

- **Server**: registers a MiniMax provider factory (`apps/server/src/providers/minimax.ts`) and wires it into the provider registry and auth/env handling.
- **CLI/TUI**: updates `btca connect` (both commander and TUI wizard) so MiniMax uses the API-key prompt path, plus adds provider metadata/links and a curated model entry.
- **Docs/lockfiles**: documents the provider and `MINIMAX_API_KEY`, and adds/locks the `vercel-minimax-ai-provider` dependency.

Key integration surface is the server’s provider registry (`apps/server/src/providers/registry.ts`) and the CLI’s curated model IDs (`apps/cli/src/connect/constants.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but likely breaks MiniMax usage due to an inconsistent curated model ID.
- Most wiring is straightforward (registry/auth/connect/docs), but the CLI’s curated MiniMax model ID (`MiniMax-M2.1`) conflicts with other repo references (`minimax-m2.1` / `minimax/minimax-m2.1`), which would cause runtime “model not found” failures when users pick the curated option.
- apps/cli/src/connect/constants.ts and apps/server/src/providers/minimax.ts (baseURL behavior already discussed in prior thread)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/connect.ts | Adds `minimax` to the provider IDs handled by `btca connect` for API-key entry and updates CLI help text. |
| apps/cli/src/connect/constants.ts | Adds MiniMax provider metadata, setup links, and curated model entry; curated MiniMax model ID appears inconsistent with other repo references (`MiniMax-M2.1` vs `minimax-m2.1`). |
| apps/cli/src/tui/components/connect-wizard.tsx | Adds `minimax` to the set of providers that use the API-key step in the TUI connect wizard. |
| apps/docs/btca.spec.md | Updates provider/auth spec docs to include MiniMax provider and `MINIMAX_API_KEY` env override. |
| apps/docs/guides/authentication.mdx | Updates authentication guide docs to include MiniMax provider and `MINIMAX_API_KEY` env override. |
| apps/server/package.json | Adds `vercel-minimax-ai-provider` dependency to support MiniMax provider. |
| apps/server/src/providers/auth.ts | Adds MiniMax auth type support, env var override, and provider auth hint text. |
| apps/server/src/providers/minimax.ts | Introduces MiniMax provider factory using `vercel-minimax-ai-provider`; baseURL default already flagged in prior thread. |
| apps/server/src/providers/registry.ts | Registers MiniMax provider in server provider registry. |
| bun.lock | Locks new `vercel-minimax-ai-provider` dependency and its transitive packages. |

</details>



<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->