### PR TITLE
feat(server): make maxSteps configurable via btca config

### DIFF
--- a/apps/docs/api-reference/local/config.mdx
+++ b/apps/docs/api-reference/local/config.mdx
@@ -3,4 +3,4 @@ title: 'Get config'
 openapi: 'GET /config'
 ---
 
-Returns the currently loaded configuration summary.
+Returns the currently loaded configuration summary, including model/provider and runtime settings like `maxSteps`.

--- a/apps/docs/api-reference/openapi.local.json
+++ b/apps/docs/api-reference/openapi.local.json
@@ -331,6 +331,7 @@
 					"provider",
 					"model",
 					"providerTimeoutMs",
+					"maxSteps",
 					"resourcesDirectory",
 					"resourceCount"
 				],
@@ -342,6 +343,9 @@
 						"type": "string"
 					},
 					"providerTimeoutMs": {
+						"type": "integer"
+					},
+					"maxSteps": {
 						"type": "integer"
 					},
 					"resourcesDirectory": {

--- a/apps/docs/guides/configuration.mdx
+++ b/apps/docs/guides/configuration.mdx
@@ -24,6 +24,7 @@ Example:
 	"$schema": "https://btca.dev/btca.schema.json",
 	"provider": "opencode",
 	"model": "claude-haiku-4-5",
+	"maxSteps": 40,
 	"dataDirectory": ".btca",
 	"providerOptions": {
 		// OpenAI-compatible providers (e.g., LM Studio)
@@ -59,6 +60,7 @@ Defaults if the global config is missing:
 - `provider`: `opencode`
 - `model`: `claude-haiku-4-5`
 - `providerTimeoutMs`: `300000`
+- `maxSteps`: `40`
 - Default resources: `svelte`, `tailwindcss`, `nextjs`
 
 If `dataDirectory` is missing and a legacy `.btca/` exists, the project config is

--- a/apps/server/src/agent/service.ts
+++ b/apps/server/src/agent/service.ts
@@ -149,6 +149,7 @@ export namespace Agent {
 					const stream = AgentLoop.stream({
 						providerId: config.provider,
 						modelId: config.model,
+						maxSteps: config.maxSteps,
 						collectionPath: collection.path,
 						vfsId: collection.vfsId,
 						agentInstructions: collection.agentInstructions,
@@ -207,6 +208,7 @@ export namespace Agent {
 				AgentLoop.run({
 					providerId: config.provider,
 					modelId: config.model,
+					maxSteps: config.maxSteps,
 					collectionPath: collection.path,
 					vfsId: collection.vfsId,
 					agentInstructions: collection.agentInstructions,

--- a/apps/server/src/config/config.test.ts
+++ b/apps/server/src/config/config.test.ts
@@ -3,7 +3,13 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
-import { Config, DEFAULT_MODEL, DEFAULT_PROVIDER, DEFAULT_RESOURCES } from './index.ts';
+import {
+	Config,
+	DEFAULT_MAX_STEPS,
+	DEFAULT_MODEL,
+	DEFAULT_PROVIDER,
+	DEFAULT_RESOURCES
+} from './index.ts';
 
 describe('Config', () => {
 	let testDir: string;
@@ -32,6 +38,7 @@ describe('Config', () => {
 
 			expect(config.provider).toBe(DEFAULT_PROVIDER);
 			expect(config.model).toBe(DEFAULT_MODEL);
+			expect(config.maxSteps).toBe(DEFAULT_MAX_STEPS);
 			expect(config.resources.length).toBe(DEFAULT_RESOURCES.length);
 			expect(config.getResource('svelte')).toBeDefined();
 		});
@@ -93,6 +100,30 @@ describe('Config', () => {
 			expect(config.model).toBe('commented-model');
 		});
 
+		it('loads maxSteps when provided in config', async () => {
+			const projectConfig = {
+				$schema: 'https://btca.dev/btca.schema.json',
+				provider: 'test-provider',
+				model: 'test-model',
+				maxSteps: 80,
+				resources: [
+					{
+						name: 'test-resource',
+						type: 'git',
+						url: 'https://github.com/test/repo',
+						branch: 'main'
+					}
+				]
+			};
+
+			await fs.writeFile(path.join(testDir, 'btca.config.jsonc'), JSON.stringify(projectConfig));
+			process.chdir(testDir);
+
+			const config = await Config.load();
+
+			expect(config.maxSteps).toBe(80);
+		});
+
 		it('getResource returns undefined for unknown resource', async () => {
 			process.chdir(testDir);
 
@@ -112,6 +143,28 @@ describe('Config', () => {
 			const invalidConfig = {
 				provider: 'test'
 				// missing required fields
+			};
+
+			await fs.writeFile(path.join(testDir, 'btca.config.jsonc'), JSON.stringify(invalidConfig));
+			process.chdir(testDir);
+
+			expect(Config.load()).rejects.toThrow('Invalid config');
+		});
+
+		it('throws ConfigError for invalid maxSteps', async () => {
+			const invalidConfig = {
+				$schema: 'https://btca.dev/btca.schema.json',
+				provider: 'test-provider',
+				model: 'test-model',
+				maxSteps: 0,
+				resources: [
+					{
+						name: 'test-resource',
+						type: 'git',
+						url: 'https://github.com/test/repo',
+						branch: 'main'
+					}
+				]
 			};
 
 			await fs.writeFile(path.join(testDir, 'btca.config.jsonc'), JSON.stringify(invalidConfig));

--- a/apps/server/src/config/index.ts
+++ b/apps/server/src/config/index.ts
@@ -19,6 +19,7 @@ export const CONFIG_SCHEMA_URL = 'https://btca.dev/btca.schema.json';
 export const DEFAULT_MODEL = 'claude-haiku-4-5';
 export const DEFAULT_PROVIDER = 'opencode';
 export const DEFAULT_PROVIDER_TIMEOUT_MS = 300_000;
+export const DEFAULT_MAX_STEPS = 40;
 
 export const DEFAULT_RESOURCES: ResourceDefinition[] = [
 	{
@@ -61,6 +62,7 @@ const StoredConfigSchema = z.object({
 	$schema: z.string().optional(),
 	dataDirectory: z.string().optional(),
 	providerTimeoutMs: z.number().int().positive().optional(),
+	maxSteps: z.number().int().positive().optional(),
 	resources: z.array(ResourceDefinitionSchema),
 	// Provider and model are optional - defaults are applied when loading
 	model: z.string().optional(),
@@ -130,6 +132,7 @@ export namespace Config {
 		model: string;
 		provider: string;
 		providerTimeoutMs?: number;
+		maxSteps: number;
 		configPath: string;
 		getProviderOptions: (providerId: string) => ProviderOptionsConfig | undefined;
 		getResource: (name: string) => ResourceDefinition | undefined;
@@ -506,7 +509,8 @@ export namespace Config {
 			resources: DEFAULT_RESOURCES,
 			model: DEFAULT_MODEL,
 			provider: DEFAULT_PROVIDER,
-			providerTimeoutMs: DEFAULT_PROVIDER_TIMEOUT_MS
+			providerTimeoutMs: DEFAULT_PROVIDER_TIMEOUT_MS,
+			maxSteps: DEFAULT_MAX_STEPS
 		};
 
 		const result = await Result.gen(async function* () {
@@ -638,6 +642,9 @@ export namespace Config {
 			},
 			get providerTimeoutMs() {
 				return getActiveConfig().providerTimeoutMs;
+			},
+			get maxSteps() {
+				return getActiveConfig().maxSteps ?? DEFAULT_MAX_STEPS;
 			},
 			getProviderOptions: (providerId: string) => getMergedProviderOptions()[providerId],
 			getResource: (name: string) => getMergedResources().find((r) => r.name === name),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -268,6 +268,7 @@ const createApp = (deps: {
 				provider: config.provider,
 				model: config.model,
 				providerTimeoutMs: config.providerTimeoutMs ?? null,
+				maxSteps: config.maxSteps,
 				resourcesDirectory: config.resourcesDirectory,
 				resourceCount: config.resources.length
 			});
@@ -501,6 +502,7 @@ export const startServer = async (options: StartServerOptions = {}): Promise<Ser
 	Metrics.info('config.ready', {
 		provider: config.provider,
 		model: config.model,
+		maxSteps: config.maxSteps,
 		resources: config.resources.map((r) => r.name),
 		resourcesDirectory: config.resourcesDirectory
 	});

--- a/apps/web/static/btca.schema.json
+++ b/apps/web/static/btca.schema.json
@@ -29,6 +29,12 @@
 			"description": "Timeout in milliseconds for provider requests (optional)",
 			"default": 300000
 		},
+		"maxSteps": {
+			"type": "integer",
+			"minimum": 1,
+			"description": "Maximum number of agent steps before stopping (optional)",
+			"default": 40
+		},
 		"providerOptions": {
 			"type": "object",
 			"description": "Per-provider options (e.g., baseURL and name for openai-compat)",

--- a/apps/web/static/docs/example-btca.config.jsonc
+++ b/apps/web/static/docs/example-btca.config.jsonc
@@ -48,5 +48,6 @@
       "name": "lmstudio"
     }
   },
-  "providerTimeoutMs": 300000
+  "providerTimeoutMs": 300000,
+  "maxSteps": 40
 }


### PR DESCRIPTION
## Summary
- add optional `maxSteps` to local `btca.config.jsonc` parsing/typing with a default of `40`
- thread `config.maxSteps` through both non-streaming and streaming agent paths
- expose active `maxSteps` in `GET /config` and startup `config.ready` metrics
- update schema/docs/OpenAPI/example config to document the new setting
- add config tests for default value, explicit override, and invalid values

## Why
`maxSteps` was previously hardcoded in the agent loop defaults, which made long-running tool-call scenarios difficult to tune per project. This keeps existing behavior (`40`) while allowing explicit configuration when needed.

## Implementation notes
- default remains 40 via `DEFAULT_MAX_STEPS`
- `maxSteps` is optional in config files and validated as a positive integer
- no CLI flag changes in this PR; configuration is file-based

## Validation
- `bun run --cwd apps/server test`
- `bun run --cwd apps/server check`
- `jq . apps/docs/api-reference/openapi.local.json`
- `jq . apps/web/static/btca.schema.json`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `maxSteps` configurable via `btca.config.jsonc`, allowing projects to override the default limit of 40 agent loop steps. The implementation is clean and backward-compatible—existing projects will continue using the default value.

- Added optional `maxSteps` field to config schema with validation (positive integer required)
- Threaded the config value through both streaming and non-streaming agent execution paths
- Exposed `maxSteps` in `GET /config` endpoint and startup metrics for visibility
- Updated all relevant documentation, schemas, and examples
- Added comprehensive test coverage for default, override, and invalid value scenarios

The change maintains existing behavior by default while enabling customization for long-running tool-call scenarios. Documentation has been properly updated per AGENTS.md requirements.

<h3>Confidence Score: 5/5</h3>

- Safe to merge—backward-compatible feature addition with comprehensive tests and documentation
- This PR is well-implemented with proper validation, comprehensive test coverage, and thorough documentation updates. The change is purely additive (optional config field) with a sensible default that preserves existing behavior. No breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/server/src/config/index.ts | Added `maxSteps` config option with proper default, validation, and getter implementation |
| apps/server/src/agent/service.ts | Threaded `config.maxSteps` through both streaming and non-streaming agent paths |
| apps/server/src/config/config.test.ts | Added comprehensive tests for default value, explicit override, and invalid `maxSteps` values |
| apps/server/src/index.ts | Exposed `maxSteps` in both `GET /config` endpoint and startup metrics |

</details>



<sub>Last reviewed commit: f0ad460</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->