### PR TITLE
fix: add wl-copy support for Wayland environments

### DIFF
--- a/apps/cli/src/tui/clipboard.ts
+++ b/apps/cli/src/tui/clipboard.ts
@@ -15,6 +15,10 @@ const isWsl = async () => {
 	}
 };
 
+const isWayland = () => {
+	return !!process.env.WAYLAND_DISPLAY;
+};
+
 export async function copyToClipboard(text: string) {
 	const platform = process.platform;
 
@@ -42,6 +46,11 @@ export async function copyToClipboard(text: string) {
 			if (!clipResult.isErr()) return;
 			const clipPathResult = await runClipboard(['/mnt/c/Windows/System32/clip.exe']);
 			if (!clipPathResult.isErr()) return;
+		}
+
+		if (isWayland()) {
+			const wlCopyResult = await runClipboard(['wl-copy']);
+			if (!wlCopyResult.isErr()) return;
 		}
 
 		// Try xclip first, fall back to xsel


### PR DESCRIPTION
## Summary
- Add Wayland clipboard support using `wl-copy` from `wl-clipboard` package
- Detect Wayland environment via `WAYLAND_DISPLAY` env variable
- Falls back to xclip/xsel if wl-copy is not available

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Wayland clipboard support to the CLI's clipboard utility by detecting the `WAYLAND_DISPLAY` environment variable and attempting `wl-copy` before falling back to `xclip`/`xsel`. This is a small, focused change that does not break existing clipboard behavior on macOS, Windows, WSL, or X11 Linux.

- Adds `isWayland()` helper that checks `process.env.WAYLAND_DISPLAY`
- Inserts `wl-copy` attempt in the Linux clipboard chain after WSL checks and before xclip/xsel fallback
- Follows existing code patterns and error handling conventions
- No plan `.md` files found in this PR
- No AGENTS.md violations detected

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a new clipboard path without altering existing behavior.
- The change is minimal (adding a new clipboard tool attempt in the existing fallback chain), follows established patterns, does not modify any existing logic paths, and gracefully falls through to existing xclip/xsel handling if wl-copy is unavailable.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/tui/clipboard.ts | Adds Wayland clipboard support via `wl-copy`, with correct ordering (after WSL, before xclip/xsel fallback) and consistent error handling. No issues found. |

</details>



<sub>Last reviewed commit: 4dcd5c7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e194ab0f-6e48-40d2-8835-266156fef6be))

<!-- /greptile_comment -->