### PR TITLE
fix: auth robustness and docs consistency

### DIFF
--- a/apps/cli/src/lib/copilot-oauth.ts
+++ b/apps/cli/src/lib/copilot-oauth.ts
@@ -41,7 +41,9 @@ const readAuthFile = async () => {
 	const file = Bun.file(filepath);
 	if (!(await file.exists())) return {};
 	try {
-		const content = await file.json();
+		const text = await file.text();
+		if (text.trim().length === 0) return {};
+		const content = JSON.parse(text) as unknown;
 		return content && typeof content === 'object' ? (content as Record<string, unknown>) : {};
 	} catch {
 		return {};

--- a/apps/cli/src/lib/opencode-oauth.ts
+++ b/apps/cli/src/lib/opencode-oauth.ts
@@ -243,7 +243,9 @@ const readAuthFile = async (): Promise<Record<string, unknown>> => {
 	const file = Bun.file(filepath);
 	if (!(await file.exists())) return {};
 	try {
-		const content = await file.json();
+		const text = await file.text();
+		if (text.trim().length === 0) return {};
+		const content = JSON.parse(text) as unknown;
 		return content && typeof content === 'object' ? (content as Record<string, unknown>) : {};
 	} catch {
 		return {};

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -48,7 +48,7 @@ Supported providers:
 - `openai` — OAuth (no API keys)
 - `openai-compat` — optional API key (requires baseURL + name in config)
 - `anthropic` — API key
-- `google` — API key or OAuth
+- `google` — API key
 - `minimax` — API key
 
 Environment variable overrides:
@@ -202,7 +202,7 @@ Options:
 
 - `-g, --global` — (flag exists; config target is still resolved by presence of project config)
 - `-n, --name <name>`
-- `-b, --branch <branch>` (default `main`)
+- `-b, --branch <branch>` (auto-detected when omitted)
 - `-s, --search-path <path...>`
 - `--notes <notes>`
 - `-t, --type <git|local|npm>`
@@ -275,6 +275,7 @@ Behavior:
 - If provider/model specified, updates config.
 - Otherwise, interactive provider selection (connected providers listed first), then model selection.
 - Prompts for auth if required.
+- Backward-compatible alias: `btca config model --provider <id> --model <id>` (deprecated).
 
 ### 4.8 `btca disconnect`
 

--- a/apps/docs/guides/authentication.mdx
+++ b/apps/docs/guides/authentication.mdx
@@ -18,7 +18,7 @@ Supported providers:
 - `github-copilot` (OAuth device flow)
 - `openai-compat` (optional API key)
 - `anthropic` (API key)
-- `google` (API key or OAuth)
+- `google` (API key)
 - `minimax` (API key)
 
 Environment variable overrides:

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -159,7 +159,7 @@ BTCA supports the following providers only:
 - `opencode` — API key required
 - `openrouter` — API key required
 - `openai` — OAuth only
-- `google` — API key or OAuth
+- `google` — API key required
 - `anthropic` — API key required
 
 Authenticate providers via OpenCode:
@@ -173,7 +173,7 @@ opencode auth --provider <provider>
 - OpenCode and OpenRouter can use environment variables or OpenCode auth.
 - OpenAI requires OAuth (API keys are not supported).
 - Anthropic requires an API key.
-- Google supports API key or OAuth.
+- Google requires an API key.
 
 ## Environment Variables
 

--- a/apps/server/src/providers/auth.ts
+++ b/apps/server/src/providers/auth.ts
@@ -27,7 +27,7 @@ export namespace Auth {
 		openai: ['oauth'],
 		'openai-compat': ['api'],
 		anthropic: ['api'],
-		google: ['api', 'oauth'],
+		google: ['api'],
 		minimax: ['api']
 	};
 
@@ -103,7 +103,11 @@ export namespace Auth {
 			return {};
 		}
 
-		const result = await Result.tryPromise(() => file.json());
+		const result = await Result.tryPromise(async () => {
+			const text = await file.text();
+			if (text.trim().length === 0) return {};
+			return JSON.parse(text) as unknown;
+		});
 		return result.match({
 			ok: (content) => {
 				const parsed = AuthFileSchema.safeParse(content);
@@ -172,7 +176,7 @@ export namespace Auth {
 			case 'anthropic':
 				return 'Run "opencode auth --provider anthropic" and enter an API key.';
 			case 'google':
-				return 'Run "opencode auth --provider google" and enter an API key or OAuth.';
+				return 'Run "btca connect -p google" and enter an API key.';
 			case 'openrouter':
 				return 'Set OPENROUTER_API_KEY or run "opencode auth --provider openrouter".';
 			case 'opencode':


### PR DESCRIPTION
## Summary
- treat empty auth.json as valid empty state
- reduce noisy auth read warnings
- align runtime + docs auth matrix for providers

## Issues
- Closes #184
- Closes #185

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves auth robustness by treating empty `auth.json` as valid empty state and aligns documentation with runtime behavior for Google provider authentication.

- Added empty file handling in auth file readers to prevent JSON parsing errors
- Removed Google OAuth support from provider auth matrix (API key only)
- Updated all documentation to consistently reflect Google requires API key authentication
- Reduced noisy warnings when reading empty auth files

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no breaking changes to existing features
- All changes are consistent, well-tested patterns for handling edge cases. The Google OAuth removal only affects documentation since OAuth wasn't actually implemented for Google provider. Empty auth.json handling prevents errors without changing existing behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/lib/copilot-oauth.ts | Added empty auth.json handling to prevent JSON parsing errors |
| apps/cli/src/lib/opencode-oauth.ts | Added empty auth.json handling to prevent JSON parsing errors |
| apps/server/src/providers/auth.ts | Added empty auth.json handling and removed Google OAuth support (API key only) |

</details>



<sub>Last reviewed commit: f403623</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->