### PR TITLE
feat: add deprecated btca config model compatibility alias

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -1,0 +1,40 @@
+import { Result } from 'better-result';
+import { Command } from 'commander';
+
+import { updateModel } from '../client/index.ts';
+import { ensureServer } from '../server/manager.ts';
+
+const configModelCommand = new Command('model')
+	.description('Deprecated alias for "btca connect --provider ... --model ..."')
+	.requiredOption('-p, --provider <id>', 'Provider ID')
+	.requiredOption('-m, --model <id>', 'Model ID')
+	.action(async (options: { provider: string; model: string }, command) => {
+		const root = command.parent?.parent;
+		const globalOpts = root?.opts() as { server?: string; port?: number } | undefined;
+
+		const result = await Result.tryPromise(async () => {
+			const server = await ensureServer({
+				serverUrl: globalOpts?.server,
+				port: globalOpts?.port,
+				quiet: true
+			});
+
+			const updated = await updateModel(server.url, options.provider, options.model);
+			server.stop();
+
+			console.warn(
+				'Deprecation: "btca config model" will be removed in a future release. Use "btca connect --provider ... --model ...".'
+			);
+			console.log(`Model updated: ${updated.provider}/${updated.model}`);
+		});
+
+		if (Result.isError(result)) {
+			const message = result.error instanceof Error ? result.error.message : String(result.error);
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	});
+
+export const configCommand = new Command('config')
+	.description('Deprecated config command compatibility aliases')
+	.addCommand(configModelCommand);

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -27,6 +27,12 @@ describe('cli dispatch', () => {
 		expect(result.output).toContain('Usage: btca add');
 	});
 
+	test('keeps nested subcommand help contextual for btca config model', () => {
+		const result = runCli(['config', 'model', '--help']);
+		expect(result.exitCode).toBe(0);
+		expect(result.output).toContain('Usage: btca config model');
+	});
+
 	test('rejects unknown top-level commands with a suggestion', () => {
 		const result = runCli(['remoev'], 250);
 		expect(result.exitCode).toBe(1);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { addCommand } from './commands/add.ts';
 import { askCommand } from './commands/ask.ts';
 import { clearCommand } from './commands/clear.ts';
+import { configCommand } from './commands/config.ts';
 import { connectCommand } from './commands/connect.ts';
 import { disconnectCommand } from './commands/disconnect.ts';
 import { initCommand } from './commands/init.ts';
@@ -53,6 +54,7 @@ program.addCommand(askCommand);
 
 // Configuration commands
 program.addCommand(connectCommand);
+program.addCommand(configCommand);
 program.addCommand(disconnectCommand);
 program.addCommand(initCommand);
 program.addCommand(statusCommand);

--- a/apps/docs/guides/cli-reference.mdx
+++ b/apps/docs/guides/cli-reference.mdx
@@ -58,7 +58,7 @@ Options:
 
 - `-g, --global` sets the flag, but target resolution still depends on whether a project config exists.
 - `-n, --name <name>` sets a resource name.
-- `-b, --branch <branch>` sets a branch (default `main`).
+- `-b, --branch <branch>` sets a branch (auto-detected when omitted).
 - `-s, --search-path <path...>` sets one or more search paths.
 - `--notes <notes>` sets special notes.
 - `-t, --type <git|local|npm>` forces the resource type.
@@ -167,6 +167,16 @@ For `openai-compat`, the interactive flow additionally prompts for:
 - Provider name (required): AI SDK provider identifier.
 - Model ID (required): saved as `model` in `btca.config.jsonc`.
 - API key (optional): only if your server requires auth, stored in OpenCode auth.
+
+## `btca config model` (compatibility alias)
+
+Backward-compatible alias for model updates:
+
+```bash
+btca config model --provider <id> --model <id>
+```
+
+This command delegates to the same update path as `btca connect` and prints a deprecation notice.
 
 ## `btca status`
 


### PR DESCRIPTION
## Summary
- add backward-compatible btca config model alias
- keep contextual help/dispatch behavior validated by tests
- document deprecation path

## Issues
- Closes #151
- Closes #152

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `btca config model` backward-compatible alias command that delegates to the same `updateModel` path as `btca connect`, prints a deprecation notice on success, and documents the removal path. The registration in `index.ts` is clean and the `--help` test covers the new nested subcommand correctly. No plan files were found in the repository.

**Key changes:**
- New `apps/cli/src/commands/config.ts` exposes a `config model` subcommand as a deprecated shim over `updateModel`.
- `apps/cli/src/index.ts` registers `configCommand` in the configuration commands block.
- `apps/cli/src/index.test.ts` adds a `--help` smoke test for the nested subcommand.
- `apps/docs/guides/cli-reference.mdx` documents the compatibility alias and corrects the `--branch` option description (`"default main"` → `"auto-detected when omitted"`).

**Issues found:**
- In `config.ts`, `server.stop()` is only reached if `updateModel` succeeds. If `updateModel` throws, the auto-started server is never stopped, which can cause port conflicts for subsequent CLI invocations.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the server resource leak in the error path of the new config command.
- The change is small and well-scoped, but the server leak in `config.ts` — where `server.stop()` is skipped when `updateModel` throws — is a real functional bug that can leave a dangling process behind.
- apps/cli/src/commands/config.ts — the `server.stop()` call needs to be moved into a `finally` block.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/config.ts | New file adding the deprecated `btca config model` compatibility alias. Contains a server resource leak — `server.stop()` is not called if `updateModel` throws. |
| apps/cli/src/index.ts | Imports and registers `configCommand`. `config` is correctly included in `knownCommands` before the unknown-command check, so typo-suggestion logic works properly for the new command. |
| apps/cli/src/index.test.ts | Adds a test verifying `btca config model --help` exits with code 0 and outputs the expected usage line. No issues found. |
| apps/docs/guides/cli-reference.mdx | Adds the `btca config model` section and updates the `--branch` description from "default `main`" to "auto-detected when omitted". No issues found. |

</details>



<sub>Last reviewed commit: 66b4cd8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->