### PR TITLE
feat: improve private repo access handling in web/sandbox flow

### DIFF
--- a/apps/web/src/convex/resources.ts
+++ b/apps/web/src/convex/resources.ts
@@ -28,6 +28,38 @@ const throwResourceError = (error: WebError): never => {
 	throw error;
 };
 
+const hasCloudGitToken = () => Boolean(process.env.BTCA_GIT_TOKEN?.trim());
+
+const isGitHubUrl = (url: string) => {
+	const parsed = Result.try(() => new URL(url)).match({
+		ok: (value) => value,
+		err: () => null
+	});
+	return parsed?.hostname.toLowerCase() === 'github.com';
+};
+
+const preflightResourceUrlAccess = async (
+	url: string
+): Promise<{ ok: true } | { ok: false; error: string }> => {
+	if (hasCloudGitToken()) return { ok: true };
+	if (!isGitHubUrl(url)) return { ok: true };
+
+	const result = await Result.tryPromise(() =>
+		fetch(url, { method: 'HEAD', redirect: 'manual' as RequestRedirect })
+	);
+	if (Result.isError(result)) return { ok: true };
+
+	if (result.value.status === 401 || result.value.status === 403 || result.value.status === 404) {
+		return {
+			ok: false,
+			error:
+				'Repository appears private or inaccessible from cloud mode. Configure BTCA_GIT_TOKEN for private repository access, or use local CLI mode.'
+		};
+	}
+
+	return { ok: true };
+};
+
 // Resource validators
 const globalResourceValidator = v.object({
 	name: v.string(),
@@ -303,6 +335,11 @@ export const addCustomResource = mutation({
 		const nameResult = validateResourceNameResult(args.name);
 		if (Result.isError(nameResult)) {
 			throwResourceError(nameResult.error);
+		}
+
+		const preflight = await preflightResourceUrlAccess(args.url);
+		if (!preflight.ok) {
+			throwResourceError(new WebValidationError({ message: preflight.error, field: 'url' }));
 		}
 
 		const resourceId = await ctx.db.insert('userResources', {


### PR DESCRIPTION
## Summary
- add cloud preflight for likely private/inaccessible repo URLs
- surface explicit auth-required guidance for cloud mode
- integrate with existing git auth path assumptions

## Issues
- Closes #191

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds early validation for private GitHub repositories during custom resource creation. The preflight check performs a HEAD request to detect if a repository is private/inaccessible and provides clear guidance to configure `BTCA_GIT_TOKEN` or use local CLI mode.

**Key Changes:**
- Implemented `preflightResourceUrlAccess()` to detect private/inaccessible GitHub repos before resource creation
- Added helpful error message directing users to configure `BTCA_GIT_TOKEN` for private repo access
- Integrated preflight check into `addCustomResource` mutation to fail early with actionable guidance

**Observations:**
- Check is limited to GitHub URLs only (GitLab, Bitbucket, etc. are not validated)
- Network/CORS errors during preflight are treated as success to avoid false positives
- Actual git operations will still fail with proper errors if repository is truly inaccessible

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Well-implemented preflight check that improves UX by providing early feedback for private repos. Code follows existing patterns, uses proper error handling with better-result, and integrates cleanly with the addCustomResource mutation. The approach is conservative (allows on network errors) to avoid false positives.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/resources.ts | Adds preflight check for private GitHub repos before resource creation, with helpful error messaging |

</details>



<sub>Last reviewed commit: 02f8ada</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->