### PR TITLE
docs: add project support and triage hygiene policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Report a reproducible bug in btca
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please include complete reproduction details so maintainers can investigate quickly.
+  - type: input
+    id: btca_version
+    attributes:
+      label: btca version
+      description: Output of `btca --version`
+      placeholder: 1.2.3
+    validations:
+      required: true
+  - type: input
+    id: bun_version
+    attributes:
+      label: Bun version
+      placeholder: 1.x.x
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS and shell
+      placeholder: macOS 14 + zsh
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command(s) run
+      description: Include the exact command and flags
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Include complete error output
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Include config/resource snippets as needed
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Support and triage policy
+    url: https://github.com/davis7dotsh/better-context/blob/main/SUPPORT.md
+    about: Review support scope, priorities, and reproduction requirements.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an improvement for btca
+labels:
+  - enhancement
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: Add support for ...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What is difficult today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+      description: Describe expected behavior or API
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Set up btca for this project: scan package.json for major dependencies (framewor
 
 See the full [Getting Started guide](https://docs.btca.dev/guides/quickstart) for more details.
 
+## Support
+
+Review [SUPPORT.md](./SUPPORT.md) for triage priorities, expected response targets, and bug report requirements.
+
 ## Development
 
 This is a Bun monorepo using Turborepo. **Only use `bun`** - never npm/yarn.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,41 @@
+# Support and Triage Policy
+
+This document explains how btca issues are prioritized and what maintainers need in order to resolve reports quickly.
+
+## Priorities
+
+1. P0: security bugs, data loss, or complete service outage
+2. P1: broken core workflows (`btca ask`, resource add/load, auth)
+3. P2: degraded UX or edge-case correctness issues
+4. P3: feature requests and polish
+
+## Expected Response Targets
+
+1. P0/P1: initial triage within 72 hours
+2. P2/P3: initial triage as capacity allows
+
+These are best-effort targets, not strict SLAs.
+
+## What To Include in Bug Reports
+
+1. Exact btca version (`btca --version`)
+2. Runtime and OS (Bun version, platform, shell/terminal)
+3. Full command you ran
+4. Full error output and stack trace (if present)
+5. Minimal reproducible config/resource example
+
+## Duplicate and Related Issues
+
+Maintainers may close issues as duplicates and link to a canonical tracking issue. This helps keep investigation and status updates in one place.
+
+## Support Scope
+
+1. Local CLI and server behavior
+2. Cloud/sandbox integration behavior
+3. Documentation and migration guidance
+
+## Out of Scope for Immediate Triage
+
+1. Unreproducible reports with no logs
+2. Provider-side incidents with no btca regression
+3. Product strategy requests without implementation details


### PR DESCRIPTION
## Summary
- add public support/triage policy document
- improve issue templates for reproducibility and routing
- link support policy from repo docs

## Issues
- Closes #190

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added comprehensive support and triage policy with structured issue templates. The changes establish clear priorities (P0-P3), response targets, and bug reporting requirements. Issue templates now collect essential information (btca version, Bun version, OS/shell, commands, and reproduction steps) aligned with SUPPORT.md requirements. All changes are purely additive with no modifications to existing functionality or breaking changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are documentation-only and purely additive, adding new support policy and issue templates without modifying any code or existing features
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug_report.yml | Added structured bug report template collecting version, environment, and reproduction details |
| .github/ISSUE_TEMPLATE/config.yml | Added issue template configuration linking to support policy |
| .github/ISSUE_TEMPLATE/feature_request.yml | Added structured feature request template with problem statement and proposed solution fields |
| README.md | Added Support section linking to SUPPORT.md for triage and bug reporting guidance |
| SUPPORT.md | Added comprehensive support policy defining priorities, response targets, and bug reporting requirements |

</details>



<sub>Last reviewed commit: d4764d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->