### PR TITLE
Effect migration validation

### DIFF
--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -117,12 +117,16 @@ const printResourceList = (label: string, resources: string[] | null) => {
 	}
 };
 
-export const runStatusCommand = async () => {
+export const runStatusCommand = async (globalOpts?: { server?: string; port?: number }) => {
 	const projectPath = path.resolve(process.cwd(), PROJECT_CONFIG_FILENAME);
 
 	return Effect.runPromise(
 		withServerEffect(
-			{ quiet: true },
+			{
+				serverUrl: globalOpts?.server,
+				port: globalOpts?.port,
+				quiet: true
+			},
 			(server) =>
 				Effect.gen(function* () {
 					const client = createClient(server.url);

--- a/apps/cli/src/effect/argv.test.ts
+++ b/apps/cli/src/effect/argv.test.ts
@@ -24,6 +24,14 @@ describe('cli argv compatibility', () => {
 		]);
 	});
 
+	test('moves root server flags behind status subcommand', () => {
+		expect(normalizeCliArgv(['--server', 'http://localhost:9999', 'status'])).toEqual([
+			'status',
+			'--server',
+			'http://localhost:9999'
+		]);
+	});
+
 	test('moves ask compatibility flags behind ask subcommand', () => {
 		expect(normalizeCliArgv(['--no-thinking', '--no-tools', 'ask', '-q', 'hi'])).toEqual([
 			'ask',

--- a/apps/cli/src/effect/argv.ts
+++ b/apps/cli/src/effect/argv.ts
@@ -19,7 +19,8 @@ const serverAwareSubcommands = new Set([
 	'disconnect',
 	'mcp',
 	'remove',
-	'resources'
+	'resources',
+	'status'
 ]);
 
 const askCompatibilityFlags = new Set([

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -1,22 +1,78 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runEffectCli } from './effect/cli-app.ts';
 
 const CLI_DIR = fileURLToPath(new URL('..', import.meta.url));
 const textFromProcessOutput = (value: Uint8Array | string | undefined) =>
 	typeof value === 'string' ? value : value ? new TextDecoder().decode(value) : '';
 
-const runCli = (argv: string[], timeout = 10_000) => {
+const runCli = (
+	argv: string[],
+	timeout = 10_000,
+	env?: Record<string, string>
+) => {
 	const result = Bun.spawnSync({
 		cmd: ['bun', 'run', 'src/index.ts', ...argv],
 		cwd: CLI_DIR,
 		stdout: 'pipe',
 		stderr: 'pipe',
-		timeout
+		timeout,
+		env: env ? { ...process.env, ...env } : process.env
 	});
 
 	return {
 		exitCode: result.exitCode,
 		output: `${textFromProcessOutput(result.stdout)}${textFromProcessOutput(result.stderr)}`
+	};
+};
+
+const withTempHome = async <T>(run: (tempHome: string) => Promise<T>): Promise<T> => {
+	const tempHome = mkdtempSync(path.join(tmpdir(), 'btca-cli-test-'));
+	const originalHome = process.env.HOME;
+	process.env.HOME = tempHome;
+	try {
+		return await run(tempHome);
+	} finally {
+		process.env.HOME = originalHome;
+		rmSync(tempHome, { recursive: true, force: true });
+	}
+};
+
+const createStubServer = () => {
+	const requestPaths: string[] = [];
+	const server = Bun.serve({
+		port: 0,
+		fetch: (request) => {
+			const url = new URL(request.url);
+			requestPaths.push(url.pathname);
+			if (url.pathname === '/') {
+				return Response.json({ ok: true });
+			}
+			if (url.pathname === '/resources') {
+				return Response.json(
+					{ error: 'stub resources error', tag: 'RequestError' },
+					{ status: 500 }
+				);
+			}
+			if (url.pathname === '/config') {
+				return Response.json({ error: 'stub config error', tag: 'RequestError' }, { status: 500 });
+			}
+			if (url.pathname === '/providers') {
+				return Response.json(
+					{ error: 'stub providers error', tag: 'RequestError' },
+					{ status: 500 }
+				);
+			}
+			return Response.json({ error: 'stub not found', tag: 'RouteNotFound' }, { status: 404 });
+		}
+	});
+	return {
+		server,
+		url: `http://127.0.0.1:${server.port}`,
+		requestPaths
 	};
 };
 
@@ -45,5 +101,48 @@ describe('cli dispatch', () => {
 		const result = runCli([], 250);
 		expect(result.exitCode).toBeNull();
 		expect(result.output).not.toContain('error: unknown command');
+	});
+
+	test('returns non-zero for missing required ask flags', () => {
+		const result = runCli(['ask']);
+		expect(result.exitCode).toBe(1);
+		expect(result.output).toContain('Missing required flag: --question');
+	});
+
+	test('returns non-zero for invalid telemetry subcommands', () => {
+		const result = runCli(['telemetry', 'foo']);
+		expect(result.exitCode).toBe(1);
+		expect(result.output).toContain('Unknown subcommand "foo" for "btca telemetry"');
+	});
+
+	test('forwards subcommand --server to resources command', async () => {
+		const stub = createStubServer();
+		try {
+			const exitCode = await withTempHome(() =>
+				runEffectCli(['bun', 'src/index.ts', 'resources', '--server', stub.url], 'test')
+			);
+			expect(exitCode).toBe(1);
+			expect(stub.requestPaths).toContain('/');
+			expect(stub.requestPaths).toContain('/resources');
+		} finally {
+			stub.server.stop();
+		}
+	});
+
+	test('forwards root --server to status command', async () => {
+		const stub = createStubServer();
+		try {
+			const exitCode = await withTempHome(() =>
+				runEffectCli(
+					['bun', 'src/index.ts', '--server', stub.url, 'status'],
+					'test'
+				)
+			);
+			expect(exitCode).toBe(1);
+			expect(stub.requestPaths).toContain('/');
+			expect(stub.requestPaths).toContain('/config');
+		} finally {
+			stub.server.stop();
+		}
 	});
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { createAgentService } from './agent/service.ts';
 import { createCollectionsService } from './collections/service.ts';
 import { load as loadConfig } from './config/index.ts';
+import { runContext } from './context/index.ts';
 import { toHttpErrorPayload } from './effect/errors.ts';
 import { createServerRuntime } from './effect/runtime.ts';
 import * as ServerServices from './effect/services.ts';
@@ -472,7 +473,10 @@ export const startServer = async (options: StartServerOptions = {}): Promise<Ser
 
 	const server = Bun.serve({
 		port: requestedPort,
-		fetch: (request) => handler(request, requestContext),
+		fetch: (request) =>
+			runContext({ requestId: crypto.randomUUID(), txDepth: 0 }, () =>
+				handler(request, requestContext)
+			),
 		idleTimeout: 60
 	});
 


### PR DESCRIPTION
Fix CLI `--server` flag propagation, correct CLI parse error exit codes, and restore server request context to address regressions from the Effect migration.

---
<p><a href="https://cursor.com/agents/bc-c0f1965b-e679-4e7b-bcf1-13a7fc26e462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0f1965b-e679-4e7b-bcf1-13a7fc26e462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses critical regressions from the Effect migration by fixing three key issues:

**Key Changes:**
- Fixed CLI `--server` flag propagation to the `status` command by adding server/port parameters and updating argument normalization
- Corrected CLI parse error exit codes by implementing custom error tracking with `hadCliErrors` flag
- Restored server request context using `runContext` wrapper with `AsyncLocalStorage` to maintain request-scoped data

**Implementation Details:**
- Added `status` to `serverAwareSubcommands` to enable proper CLI argument reordering
- Updated `runStatusCommand` to accept `globalOpts` with server/port configuration
- Implemented custom `CliOutput` formatter that tracks parsing errors and ensures non-zero exit codes
- Wrapped server fetch handler with `runContext` to generate unique request IDs and maintain transaction depth

All changes include corresponding test coverage and follow the existing patterns in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-tested with comprehensive test coverage, follow existing patterns in the codebase, and directly address specific regression issues from the Effect migration. The implementation is straightforward with no complex logic changes, and the fixes restore expected functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/cli/src/commands/status.ts | Added globalOpts parameter to enable `--server` and `--port` flag support for the status command |
| apps/cli/src/effect/cli-app.ts | Added server/port flags to status command, implemented CLI parse error tracking with custom formatter, and fixed exit code handling |
| apps/cli/src/index.test.ts | Added comprehensive test coverage for CLI exit codes and server flag forwarding behavior |
| apps/server/src/index.ts | Restored request context by wrapping fetch handler with runContext to maintain AsyncLocalStorage context across requests |

</details>



<sub>Last reviewed commit: 7e2f17d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->