### PR TITLE
bump bun to 1.3.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "@btca/repo",
       "devDependencies": {
-        "@types/bun": "^1.3.9",
-        "@typescript/native-preview": "^7.0.0-dev.20260302.1",
+        "@types/bun": "^1.3.10",
+        "@typescript/native-preview": "^7.0.0-dev.20260303.1",
         "prettier": "^3.8.1",
-        "prettier-plugin-svelte": "^3.5.0",
+        "prettier-plugin-svelte": "^3.5.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
-        "turbo": "^2.8.12",
+        "turbo": "^2.8.13",
         "typescript": "^5.9.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"engines": {
 		"bun": ">=1.1.0"
 	},
-	"packageManager": "bun@1.3.9",
+	"packageManager": "bun@1.3.10",
 	"scripts": {
 		"dev:web": "turbo dev --filter=@btca/web",
 		"dev:docs": "bun run --cwd apps/docs dev",


### PR DESCRIPTION
# Issue
ARM64 binaries on Raspberry Pi 4 do not work with the current Bun version

## Summary
- bump Bun to 1.3.10 to align package manager version
- update lockfile deps from the Bun upgrade
- Bun 1.3.10 fixes ARM64 binaries on Raspberry Pi 4

## Testing
```shell
$ ./dist/btca-linux-arm64 -v

btca v2.0.3
```