### PR TITLE
Make cache-backed resource materialization concurrency-safe

### DIFF
--- a/apps/docs/api-reference/local/clear.mdx
+++ b/apps/docs/api-reference/local/clear.mdx
@@ -1,6 +1,8 @@
 ---
-title: 'Clear cached resources'
+title: 'Clear cached BTCA resource data'
 openapi: 'POST /clear'
 ---
 
-Clears all locally cached resource clones.
+Clears cache-backed BTCA resource data, including git mirrors, npm caches, temporary anonymous npm caches, and leftover legacy cache directories.
+
+This operation is lock-aware: it waits for active clear/resource locks and can reclaim stale locks before removing cached data.

--- a/apps/docs/api-reference/local/clear.mdx
+++ b/apps/docs/api-reference/local/clear.mdx
@@ -3,6 +3,6 @@ title: 'Clear cached BTCA resource data'
 openapi: 'POST /clear'
 ---
 
-Clears cache-backed BTCA resource data, including git mirrors, npm caches, temporary anonymous npm caches, and leftover legacy cache directories.
+Clears cache-backed BTCA resource data, including git mirrors, temporary anonymous git caches, npm caches, temporary anonymous npm caches, and leftover legacy cache directories.
 
 This operation is lock-aware: it waits for active clear/resource locks and can reclaim stale locks before removing cached data.

--- a/apps/docs/api-reference/openapi.local.json
+++ b/apps/docs/api-reference/openapi.local.json
@@ -278,7 +278,7 @@
 		"/clear": {
 			"post": {
 				"summary": "Clear cached BTCA resource data",
-				"description": "Clears cache-backed BTCA resource data, including git mirrors, npm caches, temporary anonymous npm caches, and leftover legacy cache directories. The operation is lock-aware and waits for active clear/resource locks, reclaiming stale locks when needed.",
+				"description": "Clears cache-backed BTCA resource data, including git mirrors, temporary anonymous git caches, npm caches, temporary anonymous npm caches, and leftover legacy cache directories. The operation is lock-aware and waits for active clear/resource locks, reclaiming stale locks when needed.",
 				"responses": {
 					"200": {
 						"description": "Clear result",

--- a/apps/docs/api-reference/openapi.local.json
+++ b/apps/docs/api-reference/openapi.local.json
@@ -277,7 +277,8 @@
 		},
 		"/clear": {
 			"post": {
-				"summary": "Clear cached resource clones",
+				"summary": "Clear cached BTCA resource data",
+				"description": "Clears cache-backed BTCA resource data, including git mirrors, npm caches, temporary anonymous npm caches, and leftover legacy cache directories. The operation is lock-aware and waits for active clear/resource locks, reclaiming stale locks when needed.",
 				"responses": {
 					"200": {
 						"description": "Clear result",
@@ -614,7 +615,8 @@
 				"required": ["cleared"],
 				"properties": {
 					"cleared": {
-						"type": "integer"
+						"type": "integer",
+						"description": "Number of cache directories removed."
 					}
 				}
 			}

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -317,7 +317,7 @@ Clears cache-backed BTCA resource data, not just git clones.
 
 Behavior:
 
-- Removes cached git mirrors, npm cache directories, temporary anonymous npm caches, and leftover legacy cache directories
+- Removes cached git mirrors, temporary anonymous git caches, npm cache directories, temporary anonymous npm caches, and leftover legacy cache directories
 - Uses the same lock-aware clearing flow as the local `/clear` endpoint so active resource work drains safely before cache data is removed
 
 ### 4.12 `btca serve`
@@ -539,7 +539,7 @@ Response:
 
 ### 6.11 `POST /clear`
 
-Clears cache-backed BTCA resource data, including git mirrors, npm caches, temporary anonymous npm caches, and leftover legacy cache directories.
+Clears cache-backed BTCA resource data, including git mirrors, temporary anonymous git caches, npm caches, temporary anonymous npm caches, and leftover legacy cache directories.
 
 The operation is lock-aware: it waits for active clear/resource locks and can reclaim stale locks before removing cached data.
 

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -313,7 +313,12 @@ Behavior:
 
 ### 4.11 `btca clear`
 
-Clears all locally cloned resources.
+Clears cache-backed BTCA resource data, not just git clones.
+
+Behavior:
+
+- Removes cached git mirrors, npm cache directories, temporary anonymous npm caches, and leftover legacy cache directories
+- Uses the same lock-aware clearing flow as the local `/clear` endpoint so active resource work drains safely before cache data is removed
 
 ### 4.12 `btca serve`
 
@@ -534,13 +539,17 @@ Response:
 
 ### 6.11 `POST /clear`
 
-Clears all cached resource clones.
+Clears cache-backed BTCA resource data, including git mirrors, npm caches, temporary anonymous npm caches, and leftover legacy cache directories.
+
+The operation is lock-aware: it waits for active clear/resource locks and can reclaim stale locks before removing cached data.
 
 Response:
 
 ```json
 { "cleared": 5 }
 ```
+
+`cleared` is the number of cache directories removed.
 
 ---
 

--- a/apps/docs/guides/cli-reference.mdx
+++ b/apps/docs/guides/cli-reference.mdx
@@ -124,7 +124,7 @@ You can also pass raw HTTPS git URLs directly instead of a configured resource n
 
 - They are normalized (for example, GitHub `.../blob/main/...` URLs become the base repo URL).
 - They use a short-lived cache key derived from a hash of the URL.
-- They are cloned into a unique system temp directory (for example `btca-anon-git-*`) and removed after the request finishes.
+- They are cloned into a unique BTCA-managed temp directory under the configured data directory (for example `.tmp/btca-anon-git-*`) and removed after the request finishes.
 - Branch detection tries `main`, then `master`, then `trunk`, then `dev`.
 - If none of those branches exist, the request fails with an instruction to add the repo as a named resource instead.
 
@@ -228,7 +228,7 @@ Clears cache-backed BTCA resource data, not just git clones.
 
 Behavior:
 
-- Removes cached git mirrors, npm cache directories, temporary anonymous npm caches, and leftover legacy cache directories.
+- Removes cached git mirrors, temporary anonymous git caches, npm cache directories, temporary anonymous npm caches, and leftover legacy cache directories.
 - Uses a lock-aware clear flow so active resource work drains before cached data is removed.
 - Reclaims stale cache locks when needed before removing cached data.
 

--- a/apps/docs/guides/cli-reference.mdx
+++ b/apps/docs/guides/cli-reference.mdx
@@ -124,7 +124,7 @@ You can also pass raw HTTPS git URLs directly instead of a configured resource n
 
 - They are normalized (for example, GitHub `.../blob/main/...` URLs become the base repo URL).
 - They use a short-lived cache key derived from a hash of the URL.
-- They are cloned into a temporary folder under `.tmp` and removed after the request finishes.
+- They are cloned into a unique system temp directory (for example `btca-anon-git-*`) and removed after the request finishes.
 - Branch detection tries `main`, then `master`, then `trunk`, then `dev`.
 - If none of those branches exist, the request fails with an instruction to add the repo as a named resource instead.
 
@@ -224,7 +224,13 @@ Behavior: Creates `btca.config.jsonc` and prompts for storage mode (`local` `.bt
 
 ## `btca clear`
 
-Clears all locally cloned resources.
+Clears cache-backed BTCA resource data, not just git clones.
+
+Behavior:
+
+- Removes cached git mirrors, npm cache directories, temporary anonymous npm caches, and leftover legacy cache directories.
+- Uses a lock-aware clear flow so active resource work drains before cached data is removed.
+- Reclaims stale cache locks when needed before removing cached data.
 
 ## `btca wipe`
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,9 +2,9 @@
 	"name": "@btca/docs",
 	"private": true,
 	"scripts": {
-		"dev": "mint dev",
+		"dev": "bunx mint dev",
 		"format": "prettier --write .",
-		"check": "mint validate --disable-openapi && mint openapi-check api-reference/openapi.local.json && mint openapi-check api-reference/openapi.cloud.json"
+		"check": "bunx mint validate --disable-openapi && bunx mint openapi-check api-reference/openapi.local.json && bunx mint openapi-check api-reference/openapi.cloud.json"
 	},
 	"dependencies": {},
 	"devDependencies": {

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -94,7 +94,7 @@ Remove a resource by name.
 POST /clear
 ```
 
-Clear all locally cloned resources.
+Clear BTCA-managed local resource caches, including named git mirrors, temporary anonymous git caches, and npm caches.
 
 ### Questions
 

--- a/apps/server/src/agent/agent.test.ts
+++ b/apps/server/src/agent/agent.test.ts
@@ -146,7 +146,6 @@ describe('Agent', () => {
 						name: 'docs',
 						fsName: 'docs',
 						type: 'local',
-						path: '/docs',
 						repoSubPaths: [],
 						loadedAt: new Date().toISOString()
 					}
@@ -194,7 +193,6 @@ describe('Agent', () => {
 						name: 'docs',
 						fsName: 'docs',
 						type: 'local',
-						path: '/docs',
 						repoSubPaths: [],
 						loadedAt: new Date().toISOString()
 					}

--- a/apps/server/src/collections/service.test.ts
+++ b/apps/server/src/collections/service.test.ts
@@ -3,39 +3,65 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import type { ConfigService } from '../config/index.ts';
-import type { ResourceDefinition } from '../resources/schema.ts';
 import type { ResourcesService } from '../resources/service.ts';
-import type { BtcaFsResource } from '../resources/types.ts';
+import type {
+	BtcaFsResource,
+	BtcaGitMaterializationMetadata,
+	BtcaLocalMaterializationMetadata,
+	BtcaNpmMaterializationMetadata
+} from '../resources/types.ts';
+import { ResourceError } from '../resources/helpers.ts';
 import { createCollectionsService } from './service.ts';
-import { disposeVirtualFs, existsInVirtualFs } from '../vfs/virtual-fs.ts';
+import { CollectionError } from './types.ts';
+import { loadLocalResource } from '../resources/impls/local.ts';
+import { shouldIgnoreCommonImportedPath } from '../resources/helpers.ts';
+import {
+	disposeVirtualFs,
+	existsInVirtualFs,
+	importDirectoryIntoVirtualFs
+} from '../vfs/virtual-fs.ts';
 
 const createFsResource = ({
 	name,
 	resourcePath,
 	type = 'local',
 	repoSubPaths = [],
-	specialAgentInstructions = ''
+	specialAgentInstructions = '',
+	metadata = {}
 }: {
 	name: string;
 	resourcePath: string;
 	type?: BtcaFsResource['type'];
 	repoSubPaths?: readonly string[];
 	specialAgentInstructions?: string;
-}) => ({
-	_tag: 'fs-based' as const,
-	name,
-	fsName: name,
-	type,
-	repoSubPaths,
-	specialAgentInstructions,
-	getAbsoluteDirectoryPath: async () => resourcePath
-});
-
-const createConfigMock = (definitions: Record<string, ResourceDefinition> = {}) =>
+	metadata?:
+		| BtcaGitMaterializationMetadata
+		| BtcaLocalMaterializationMetadata
+		| BtcaNpmMaterializationMetadata;
+}) =>
 	({
-		getResource: (name: string) => definitions[name]
-	}) as unknown as ConfigService;
+		_tag: 'fs-based' as const,
+		name,
+		fsName: name,
+		type,
+		repoSubPaths,
+		specialAgentInstructions,
+		materializeIntoVirtualFs: async ({
+			destinationPath,
+			vfsId
+		}: {
+			destinationPath: string;
+			vfsId: string;
+		}) => {
+			await importDirectoryIntoVirtualFs({
+				sourcePath: resourcePath,
+				destinationPath,
+				vfsId,
+				ignore: shouldIgnoreCommonImportedPath
+			});
+			return { metadata };
+		}
+	}) as BtcaFsResource;
 
 const createResourcesMock = (loadPromise: ResourcesService['loadPromise']) =>
 	({
@@ -68,8 +94,14 @@ describe('createCollectionsService', () => {
 	it('imports git-backed local resources from tracked and unignored files only', async () => {
 		const resourcePath = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-collections-git-'));
 		const collections = createCollectionsService({
-			config: createConfigMock(),
-			resources: createResourcesMock(async () => createFsResource({ name: 'repo', resourcePath }))
+			resources: createResourcesMock(async () =>
+				loadLocalResource({
+					type: 'local',
+					name: 'repo',
+					path: resourcePath,
+					specialAgentInstructions: ''
+				})
+			)
 		});
 
 		try {
@@ -102,8 +134,14 @@ describe('createCollectionsService', () => {
 	it('falls back to directory import and still skips heavy local build directories', async () => {
 		const resourcePath = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-collections-local-'));
 		const collections = createCollectionsService({
-			config: createConfigMock(),
-			resources: createResourcesMock(async () => createFsResource({ name: 'repo', resourcePath }))
+			resources: createResourcesMock(async () =>
+				loadLocalResource({
+					type: 'local',
+					name: 'repo',
+					path: resourcePath,
+					specialAgentInstructions: ''
+				})
+			)
 		});
 
 		try {
@@ -135,23 +173,18 @@ describe('createCollectionsService', () => {
 	it('includes git citation metadata in agent instructions', async () => {
 		const resourcePath = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-collections-git-meta-'));
 		const collections = createCollectionsService({
-			config: createConfigMock({
-				docs: {
-					type: 'git',
-					name: 'docs',
-					url: 'https://github.com/example/repo.git',
-					branch: 'main',
-					searchPath: 'guides',
-					specialNotes: 'Prefer the guides folder.'
-				}
-			}),
 			resources: createResourcesMock(async () =>
 				createFsResource({
 					name: 'docs',
 					resourcePath,
 					type: 'git',
 					repoSubPaths: ['guides'],
-					specialAgentInstructions: 'Prefer the guides folder.'
+					specialAgentInstructions: 'Prefer the guides folder.',
+					metadata: {
+						url: 'https://github.com/example/repo.git',
+						branch: 'main',
+						commit: 'abc123'
+					}
 				})
 			)
 		});
@@ -178,9 +211,47 @@ describe('createCollectionsService', () => {
 					'<citation_rule>Convert virtual paths under ./docs/ to repo-relative paths, then encode each path segment for GitHub URLs.</citation_rule>'
 				);
 				expect(collection.agentInstructions).toContain('<path>./docs/guides</path>');
-				expect(collection.agentInstructions).toContain('<repo_commit>');
+				expect(collection.agentInstructions).toContain('<repo_commit>abc123</repo_commit>');
 				expect(collection.agentInstructions).toContain(
 					'<special_notes>Prefer the guides folder.</special_notes>'
+				);
+			} finally {
+				await cleanupCollection(collection);
+			}
+		} finally {
+			await fs.rm(resourcePath, { recursive: true, force: true });
+		}
+	});
+
+	it('uses the resolved anonymous git fallback branch in agent instructions', async () => {
+		const resourcePath = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-collections-git-fallback-'));
+		const collections = createCollectionsService({
+			resources: createResourcesMock(async () =>
+				createFsResource({
+					name: 'anonymous:https://github.com/example/repo.git',
+					resourcePath,
+					type: 'git',
+					repoSubPaths: [],
+					metadata: {
+						url: 'https://github.com/example/repo.git',
+						branch: 'trunk',
+						commit: 'deadbeef'
+					}
+				})
+			)
+		});
+
+		try {
+			await fs.writeFile(path.join(resourcePath, 'README.md'), 'fallback branch docs\n');
+
+			const collection = await collections.loadPromise({
+				resourceNames: ['anonymous:https://github.com/example/repo.git']
+			});
+
+			try {
+				expect(collection.agentInstructions).toContain('<repo_branch>trunk</repo_branch>');
+				expect(collection.agentInstructions).toContain(
+					'<github_blob_prefix>https://github.com/example/repo/blob/trunk</github_blob_prefix>'
 				);
 			} finally {
 				await cleanupCollection(collection);
@@ -193,34 +264,22 @@ describe('createCollectionsService', () => {
 	it('includes npm citation metadata in agent instructions', async () => {
 		const resourcePath = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-collections-npm-meta-'));
 		const collections = createCollectionsService({
-			config: createConfigMock({
-				react: {
-					type: 'npm',
-					name: 'react',
-					package: 'react',
-					version: '19.0.0',
-					specialNotes: 'Use package docs.'
-				}
-			}),
 			resources: createResourcesMock(async () =>
 				createFsResource({
 					name: 'react',
 					resourcePath,
 					type: 'npm',
-					specialAgentInstructions: 'Use package docs.'
+					specialAgentInstructions: 'Use package docs.',
+					metadata: {
+						package: 'react',
+						version: '19.0.0',
+						url: 'https://www.npmjs.com/package/react'
+					}
 				})
 			)
 		});
 
 		try {
-			await fs.writeFile(
-				path.join(resourcePath, '.btca-npm-meta.json'),
-				JSON.stringify({
-					packageName: 'react',
-					resolvedVersion: '19.0.0',
-					packageUrl: 'https://www.npmjs.com/package/react'
-				})
-			);
 			await fs.writeFile(path.join(resourcePath, 'README.md'), 'react docs\n');
 
 			const collection = await collections.loadPromise({ resourceNames: ['react'] });
@@ -252,5 +311,48 @@ describe('createCollectionsService', () => {
 		} finally {
 			await fs.rm(resourcePath, { recursive: true, force: true });
 		}
+	});
+
+	it('preserves per-resource materialization errors and hints', async () => {
+		const collections = createCollectionsService({
+			resources: createResourcesMock(async (name) => {
+				if (name !== 'broken-docs') {
+					throw new Error(`unexpected resource ${name}`);
+				}
+
+				return {
+					_tag: 'fs-based',
+					name: 'broken-docs',
+					fsName: 'broken-docs',
+					type: 'git',
+					repoSubPaths: [],
+					specialAgentInstructions: '',
+					materializeIntoVirtualFs: async () => {
+						throw new ResourceError({
+							message: 'Branch "missing" not found in the repository',
+							hint: 'Verify the branch name exists in the repository. Common branches are "main", "master", "trunk", or "dev".',
+							cause: new Error('remote ref missing')
+						});
+					}
+				} satisfies BtcaFsResource;
+			})
+		});
+
+		let caught: unknown;
+		try {
+			await collections.loadPromise({ resourceNames: ['broken-docs'] });
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(CollectionError);
+		expect((caught as CollectionError).message).toBe(
+			'Failed to materialize resource "broken-docs"'
+		);
+		expect((caught as CollectionError).code).toBe('RESOURCE_MATERIALIZE_FAILED');
+		expect((caught as CollectionError).resourceName).toBe('broken-docs');
+		expect((caught as CollectionError).hint).toBe(
+			'Verify the branch name exists in the repository. Common branches are "main", "master", "trunk", or "dev".'
+		);
 	});
 });

--- a/apps/server/src/collections/service.ts
+++ b/apps/server/src/collections/service.ts
@@ -2,20 +2,15 @@ import path from 'node:path';
 
 import { Effect } from 'effect';
 
-import type { ConfigService as ConfigServiceShape } from '../config/index.ts';
 import { runTransaction } from '../context/transaction.ts';
 import { CommonHints, getErrorHint, getErrorMessage } from '../errors.ts';
 import { metricsInfo } from '../metrics/index.ts';
 import type { ResourcesService } from '../resources/service.ts';
-import { isGitResource, isNpmResource } from '../resources/schema.ts';
 import { FS_RESOURCE_SYSTEM_NOTE, type BtcaFsResource } from '../resources/types.ts';
-import { parseNpmReference } from '../validation/index.ts';
 import { CollectionError, getCollectionKey, type CollectionResult } from './types.ts';
 import {
 	createVirtualFs,
 	disposeVirtualFs,
-	importDirectoryIntoVirtualFs,
-	importPathsIntoVirtualFs,
 	mkdirVirtualFs,
 	rmVirtualFs
 } from '../vfs/virtual-fs.ts';
@@ -150,53 +145,6 @@ const ignoreErrors = async (action: () => Promise<unknown>) => {
 	}
 };
 
-const LOCAL_RESOURCE_IGNORED_DIRECTORIES = new Set([
-	'.git',
-	'.turbo',
-	'.next',
-	'.svelte-kit',
-	'.vercel',
-	'.cache',
-	'coverage',
-	'dist',
-	'build',
-	'out',
-	'node_modules'
-]);
-
-const normalizeRelativePath = (value: string) => value.split(path.sep).join('/');
-
-const shouldIgnoreImportedPath = (resource: BtcaFsResource, relativePath: string) => {
-	const normalized = normalizeRelativePath(relativePath);
-	if (!normalized || normalized === '.') return false;
-	const segments = normalized.split('/');
-	if (segments.includes('.git')) return true;
-	if (resource.type !== 'local') return false;
-	return segments.some((segment) => LOCAL_RESOURCE_IGNORED_DIRECTORIES.has(segment));
-};
-
-const listGitVisiblePaths = async (resourcePath: string) => {
-	try {
-		const proc = Bun.spawn(
-			['git', 'ls-files', '-z', '--cached', '--others', '--exclude-standard'],
-			{
-				cwd: resourcePath,
-				stdout: 'pipe',
-				stderr: 'ignore'
-			}
-		);
-		const stdout = await new Response(proc.stdout).text();
-		const exitCode = await proc.exited;
-		if (exitCode !== 0) return null;
-		return stdout
-			.split('\0')
-			.map((entry) => entry.trim())
-			.filter((entry) => entry.length > 0);
-	} catch {
-		return null;
-	}
-};
-
 const initVirtualRoot = async (collectionPath: string, vfsId: string) => {
 	try {
 		await mkdirVirtualFs(collectionPath, { recursive: true }, vfsId);
@@ -214,173 +162,39 @@ const loadResource = async (resources: ResourcesService, name: string, quiet: bo
 		return await resources.loadPromise(name, { quiet });
 	} catch (cause) {
 		const underlyingHint = getErrorHint(cause);
-		const underlyingMessage = getErrorMessage(cause);
 		throw new CollectionError({
-			message: `Failed to load resource "${name}": ${underlyingMessage}`,
+			message: `Failed to load resource "${name}"`,
 			hint:
 				underlyingHint ??
 				`${CommonHints.CLEAR_CACHE} Check that the resource "${name}" is correctly configured.`,
-			cause
+			cause,
+			code: 'RESOURCE_LOAD_FAILED',
+			resourceName: name
 		});
 	}
 };
 
-const resolveResourcePath = async (resource: BtcaFsResource) => {
+const materializeResource = async (
+	resource: BtcaFsResource,
+	args: { destinationPath: string; vfsId: string }
+) => {
 	try {
-		return await resource.getAbsoluteDirectoryPath();
+		return await resource.materializeIntoVirtualFs(args);
 	} catch (cause) {
+		const underlyingHint = getErrorHint(cause);
 		throw new CollectionError({
-			message: `Failed to get path for resource "${resource.name}"`,
-			hint: CommonHints.CLEAR_CACHE,
-			cause
+			message: `Failed to materialize resource "${resource.name}"`,
+			hint:
+				underlyingHint ??
+				`${CommonHints.CLEAR_CACHE} Check that the resource "${resource.name}" is correctly configured.`,
+			cause,
+			code: 'RESOURCE_MATERIALIZE_FAILED',
+			resourceName: resource.name
 		});
 	}
-};
-
-const virtualizeResource = async (args: {
-	resource: BtcaFsResource;
-	resourcePath: string;
-	virtualResourcePath: string;
-	vfsId: string;
-}) => {
-	try {
-		if (args.resource.type === 'local') {
-			const gitVisiblePaths = await listGitVisiblePaths(args.resourcePath);
-			if (gitVisiblePaths) {
-				await importPathsIntoVirtualFs({
-					sourcePath: args.resourcePath,
-					destinationPath: args.virtualResourcePath,
-					relativePaths: gitVisiblePaths,
-					vfsId: args.vfsId
-				});
-				return;
-			}
-		}
-
-		await importDirectoryIntoVirtualFs({
-			sourcePath: args.resourcePath,
-			destinationPath: args.virtualResourcePath,
-			vfsId: args.vfsId,
-			ignore: (relativePath) => shouldIgnoreImportedPath(args.resource, relativePath)
-		});
-	} catch (cause) {
-		throw new CollectionError({
-			message: `Failed to virtualize resource "${args.resource.name}"`,
-			hint: CommonHints.CLEAR_CACHE,
-			cause
-		});
-	}
-};
-
-const getGitHeadHash = async (resourcePath: string) => {
-	try {
-		const proc = Bun.spawn(['git', 'rev-parse', 'HEAD'], {
-			cwd: resourcePath,
-			stdout: 'pipe',
-			stderr: 'pipe'
-		});
-		const stdout = await new Response(proc.stdout).text();
-		const exitCode = await proc.exited;
-		if (exitCode !== 0) return undefined;
-		const trimmed = stdout.trim();
-		return trimmed.length > 0 ? trimmed : undefined;
-	} catch {
-		return undefined;
-	}
-};
-
-const getGitHeadBranch = async (resourcePath: string) => {
-	try {
-		const proc = Bun.spawn(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], {
-			cwd: resourcePath,
-			stdout: 'pipe',
-			stderr: 'pipe'
-		});
-		const stdout = await new Response(proc.stdout).text();
-		const exitCode = await proc.exited;
-		if (exitCode !== 0) return undefined;
-		const trimmed = stdout.trim();
-		if (!trimmed || trimmed === 'HEAD') return undefined;
-		return trimmed;
-	} catch {
-		return undefined;
-	}
-};
-
-const ANON_PREFIX = 'anonymous:';
-const getAnonymousUrlFromName = (name: string) =>
-	name.startsWith(ANON_PREFIX) ? name.slice(ANON_PREFIX.length) : undefined;
-const NPM_ANON_PREFIX = `${ANON_PREFIX}npm:`;
-const NPM_META_FILE = '.btca-npm-meta.json';
-const getAnonymousNpmReferenceFromName = (name: string) =>
-	name.startsWith(NPM_ANON_PREFIX) ? name.slice(ANON_PREFIX.length) : undefined;
-
-const readNpmMeta = async (resourcePath: string) => {
-	try {
-		const content = await Bun.file(path.join(resourcePath, NPM_META_FILE)).text();
-		return JSON.parse(content) as {
-			packageName?: string;
-			resolvedVersion?: string;
-			packageUrl?: string;
-		};
-	} catch {
-		return null;
-	}
-};
-
-const buildVirtualMetadata = async (args: {
-	resource: BtcaFsResource;
-	resourcePath: string;
-	loadedAt: string;
-	definition?: ReturnType<ConfigServiceShape['getResource']>;
-}) => {
-	const base = {
-		name: args.resource.name,
-		fsName: args.resource.fsName,
-		type: args.resource.type,
-		path: args.resourcePath,
-		repoSubPaths: args.resource.repoSubPaths,
-		loadedAt: args.loadedAt
-	};
-
-	if (args.resource.type === 'npm') {
-		const configuredDefinition =
-			args.definition && isNpmResource(args.definition) ? args.definition : null;
-		const anonymousReference = getAnonymousNpmReferenceFromName(args.resource.name);
-		const anonymousNpm = anonymousReference ? parseNpmReference(anonymousReference) : null;
-		const cached = await readNpmMeta(args.resourcePath);
-		const packageName =
-			configuredDefinition?.package ?? cached?.packageName ?? anonymousNpm?.packageName;
-		const version =
-			configuredDefinition?.version ?? cached?.resolvedVersion ?? anonymousNpm?.version;
-		const url = cached?.packageUrl ?? anonymousNpm?.packageUrl;
-
-		return {
-			...base,
-			...(packageName ? { package: packageName } : {}),
-			...(version ? { version } : {}),
-			...(url ? { url } : {})
-		};
-	}
-
-	if (args.resource.type !== 'git') return base;
-
-	const configuredDefinition =
-		args.definition && isGitResource(args.definition) ? args.definition : null;
-	const url = configuredDefinition?.url ?? getAnonymousUrlFromName(args.resource.name);
-	const branch = configuredDefinition?.branch ?? (await getGitHeadBranch(args.resourcePath));
-	const commit = await getGitHeadHash(args.resourcePath);
-
-	return {
-		...base,
-		...(url ? { url } : {}),
-		...(branch ? { branch } : {}),
-		...(commit ? { commit } : {})
-	};
 };
 
 export const createCollectionsService = (args: {
-	config: ConfigServiceShape;
 	resources: ResourcesService;
 }): CollectionsService => {
 	const loadPromise: CollectionsService['loadPromise'] = ({ resourceNames, quiet = false }) =>
@@ -423,28 +237,25 @@ export const createCollectionsService = (args: {
 				const metadataResources: VirtualResourceMetadata[] = [];
 				const loadedAt = new Date().toISOString();
 				for (const resource of loadedResources) {
-					const resourcePath = await resolveResourcePath(resource);
 					const virtualResourcePath = path.posix.join('/', resource.fsName);
 
 					await ignoreErrors(() =>
 						rmVirtualFs(virtualResourcePath, { recursive: true, force: true }, vfsId)
 					);
 
-					await virtualizeResource({
-						resource,
-						resourcePath,
-						virtualResourcePath,
+					const result = await materializeResource(resource, {
+						destinationPath: virtualResourcePath,
 						vfsId
 					});
 
-					const definition = args.config.getResource(resource.name);
-					const metadata = await buildVirtualMetadata({
-						resource,
-						resourcePath,
+					metadataResources.push({
+						name: resource.name,
+						fsName: resource.fsName,
+						type: resource.type,
+						repoSubPaths: resource.repoSubPaths,
 						loadedAt,
-						definition
+						...result.metadata
 					});
-					if (metadata) metadataResources.push(metadata);
 				}
 
 				setVirtualCollectionMetadata({

--- a/apps/server/src/collections/types.ts
+++ b/apps/server/src/collections/types.ts
@@ -8,15 +8,25 @@ export type CollectionResult = {
 	cleanup?: () => Promise<void>;
 };
 
+export type CollectionErrorCode = 'RESOURCE_LOAD_FAILED' | 'RESOURCE_MATERIALIZE_FAILED';
+
 export class CollectionError extends Error {
 	readonly _tag = 'CollectionError';
-	override readonly cause?: unknown;
+	declare readonly cause?: unknown;
 	readonly hint?: string;
+	readonly code?: CollectionErrorCode;
+	readonly resourceName?: string;
 
-	constructor(args: TaggedErrorOptions) {
-		super(args.message);
-		this.cause = args.cause;
+	constructor(
+		args: TaggedErrorOptions & {
+			code?: CollectionErrorCode;
+			resourceName?: string;
+		}
+	) {
+		super(args.message, args.cause === undefined ? undefined : { cause: args.cause });
 		this.hint = args.hint;
+		this.code = args.code;
+		this.resourceName = args.resourceName;
 	}
 }
 

--- a/apps/server/src/collections/virtual-metadata.ts
+++ b/apps/server/src/collections/virtual-metadata.ts
@@ -2,7 +2,6 @@ export type VirtualResourceMetadata = {
 	name: string;
 	fsName: string;
 	type: 'git' | 'local' | 'npm';
-	path: string;
 	repoSubPaths: readonly string[];
 	url?: string;
 	branch?: string;

--- a/apps/server/src/config/index.ts
+++ b/apps/server/src/config/index.ts
@@ -144,7 +144,6 @@ export type ConfigService = {
 	) => Effect.Effect<{ provider: string; model: string; savedTo: ConfigScope }, unknown>;
 	addResource: (resource: ResourceDefinition) => Effect.Effect<ResourceDefinition, unknown>;
 	removeResource: (name: string) => Effect.Effect<void, unknown>;
-	clearResources: () => Effect.Effect<{ cleared: number }, unknown>;
 	reload: () => Effect.Effect<void, unknown>;
 };
 
@@ -612,29 +611,6 @@ const makeService = (
 		}
 	};
 
-	const clearResourcesPromise = async (): Promise<{ cleared: number }> => {
-		let clearedCount = 0;
-
-		let resourcesDir: string[] = [];
-		try {
-			resourcesDir = await fs.readdir(resourcesDirectory);
-		} catch {
-			resourcesDir = [];
-		}
-
-		for (const item of resourcesDir) {
-			try {
-				await fs.rm(`${resourcesDirectory}/${item}`, { recursive: true, force: true });
-				clearedCount++;
-			} catch {
-				break;
-			}
-		}
-
-		metricsInfo('config.resources.cleared', { count: clearedCount });
-		return { cleared: clearedCount };
-	};
-
 	const reloadPromise = async (): Promise<void> => {
 		metricsInfo('config.reload.start', { configPath });
 
@@ -692,11 +668,6 @@ const makeService = (
 		removeResource: (name) =>
 			Effect.tryPromise({
 				try: () => removeResourcePromise(name),
-				catch: (cause) => cause
-			}),
-		clearResources: () =>
-			Effect.tryPromise({
-				try: () => clearResourcesPromise(),
 				catch: (cause) => cause
 			}),
 		reload: () =>

--- a/apps/server/src/effect/layers.ts
+++ b/apps/server/src/effect/layers.ts
@@ -2,19 +2,22 @@ import { Layer, ServiceMap, pipe } from 'effect';
 import type { AgentService as AgentServiceShape } from '../agent/service.ts';
 import type { CollectionsService as CollectionsServiceShape } from '../collections/service.ts';
 import type { ConfigService as ConfigServiceShape } from '../config/index.ts';
-import { AgentService, CollectionsService, ConfigService } from './services.ts';
+import type { ResourcesService as ResourcesServiceShape } from '../resources/service.ts';
+import { AgentService, CollectionsService, ConfigService, ResourcesService } from './services.ts';
 
 export type ServerLayerDependencies = {
 	config: ConfigServiceShape;
 	collections: CollectionsServiceShape;
 	agent: AgentServiceShape;
+	resources: ResourcesServiceShape;
 };
 
 export const makeServerLayer = (dependencies: ServerLayerDependencies) =>
 	Layer.mergeAll(
 		Layer.succeed(ConfigService, dependencies.config),
 		Layer.succeed(CollectionsService, dependencies.collections),
-		Layer.succeed(AgentService, dependencies.agent)
+		Layer.succeed(AgentService, dependencies.agent),
+		Layer.succeed(ResourcesService, dependencies.resources)
 	);
 
 export const makeServerServiceMap = (dependencies: ServerLayerDependencies) =>
@@ -22,5 +25,6 @@ export const makeServerServiceMap = (dependencies: ServerLayerDependencies) =>
 		ServiceMap.empty(),
 		ServiceMap.add(ConfigService, dependencies.config),
 		ServiceMap.add(CollectionsService, dependencies.collections),
-		ServiceMap.add(AgentService, dependencies.agent)
+		ServiceMap.add(AgentService, dependencies.agent),
+		ServiceMap.add(ResourcesService, dependencies.resources)
 	);

--- a/apps/server/src/effect/services.ts
+++ b/apps/server/src/effect/services.ts
@@ -3,6 +3,7 @@ import type { AgentService as AgentServiceShape } from '../agent/service.ts';
 import type { CollectionsService as CollectionsServiceShape } from '../collections/service.ts';
 import { getCollectionKey } from '../collections/types.ts';
 import type { ConfigService as ConfigServiceShape } from '../config/index.ts';
+import type { ResourcesService as ResourcesServiceShape } from '../resources/service.ts';
 import type { ResourceDefinition } from '../resources/schema.ts';
 
 export class ConfigService extends ServiceMap.Service<ConfigService, ConfigServiceShape>()(
@@ -18,9 +19,14 @@ export class AgentService extends ServiceMap.Service<AgentService, AgentServiceS
 	'btca-server/effect/AgentService'
 ) {}
 
+export class ResourcesService extends ServiceMap.Service<ResourcesService, ResourcesServiceShape>()(
+	'btca-server/effect/ResourcesService'
+) {}
+
 const configService = Effect.service(ConfigService);
 const collectionsService = Effect.service(CollectionsService);
 const agentService = Effect.service(AgentService);
+const resourcesService = Effect.service(ResourcesService);
 
 export type ConfigSnapshot = {
 	provider: string;
@@ -138,8 +144,8 @@ export const addConfigResource = (
 export const removeConfigResource = (name: string): Effect.Effect<void, unknown, ConfigService> =>
 	Effect.flatMap(configService, (config) => config.removeResource(name));
 
-export const clearConfigResources = Effect.flatMap(configService, (config) =>
-	config.clearResources()
+export const clearResourceCaches = Effect.flatMap(resourcesService, (resources) =>
+	resources.clearCaches()
 );
 
 export const loadedResourceCollectionKey = (resourceNames: readonly string[]) =>

--- a/apps/server/src/errors.test.ts
+++ b/apps/server/src/errors.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 
+import { CollectionError } from './collections/types.ts';
 import { formatErrorForDisplay, getErrorHint, getErrorMessage, getErrorTag } from './errors.ts';
+import { ResourceError } from './resources/helpers.ts';
 
 describe('errors', () => {
 	it('unwraps panic wrappers to the underlying tagged error details', () => {
@@ -48,6 +50,50 @@ describe('errors', () => {
 			'Failed to load resource "npm:prettier": missing docs index'
 		);
 		expect(getErrorHint(error)).toBe('Try running "btca clear" and reload resources.');
+	});
+
+	it('formats structured collection errors with contextual wrapper text plus cause details', () => {
+		const error = {
+			_tag: 'CollectionError',
+			code: 'RESOURCE_MATERIALIZE_FAILED',
+			resourceName: 'broken-docs',
+			message: 'Failed to materialize resource "broken-docs"',
+			hint: 'Verify the branch name exists in the repository.',
+			cause: {
+				_tag: 'ResourceError',
+				message: 'Branch "missing" not found in the repository',
+				hint: 'Verify the branch name exists in the repository.'
+			}
+		};
+
+		expect(getErrorTag(error)).toBe('CollectionError');
+		expect(getErrorMessage(error)).toBe(
+			'Failed to materialize resource "broken-docs": Branch "missing" not found in the repository'
+		);
+		expect(getErrorHint(error)).toBe('Verify the branch name exists in the repository.');
+	});
+
+	it('preserves cause on real CollectionError instances without reassigning it', () => {
+		const cause = new ResourceError({
+			message: 'Branch "missing" not found in the repository',
+			hint: 'Verify the branch name exists in the repository.'
+		});
+		const error = new CollectionError({
+			message: 'Failed to materialize resource "broken-docs"',
+			code: 'RESOURCE_MATERIALIZE_FAILED',
+			resourceName: 'broken-docs',
+			cause
+		});
+
+		expect(error.cause).toBe(cause);
+		expect(getErrorTag(error)).toBe('CollectionError');
+		expect(getErrorMessage(error)).toBe(
+			'Failed to materialize resource "broken-docs": Branch "missing" not found in the repository'
+		);
+		expect(getErrorHint(error)).toBe('Verify the branch name exists in the repository.');
+		expect(formatErrorForDisplay(error)).toBe(
+			'Failed to materialize resource "broken-docs": Branch "missing" not found in the repository\n\nHint: Verify the branch name exists in the repository.'
+		);
 	});
 
 	it('handles cyclic cause chains without throwing', () => {

--- a/apps/server/src/errors.ts
+++ b/apps/server/src/errors.ts
@@ -16,7 +16,7 @@ const WRAPPER_TAGS = new Set(['Panic', 'UnhandledException']);
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === 'object' && value !== null;
 
-const readStringField = (value: unknown, field: '_tag' | 'message' | 'hint') => {
+const readStringField = (value: unknown, field: string) => {
 	if (!isObjectRecord(value) || !(field in value)) return undefined;
 	const candidate = value[field];
 	return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined;
@@ -50,6 +50,17 @@ const isWrapperEntry = (entry: unknown) => {
 	return (
 		isAgentWrapper || (tag !== undefined && WRAPPER_TAGS.has(tag)) || isWrapperMessage(message)
 	);
+};
+
+const getCollectionDisplayMessage = (error: unknown) => {
+	if (!isObjectRecord(error)) return undefined;
+	if (readStringField(error, '_tag') !== 'CollectionError') return undefined;
+	const code = readStringField(error, 'code');
+	if (code !== 'RESOURCE_LOAD_FAILED' && code !== 'RESOURCE_MATERIALIZE_FAILED') return undefined;
+	const message = readStringField(error, 'message');
+	const cause = readCauseField(error);
+	if (!message || cause === undefined || cause === error) return message;
+	return `${message}: ${getErrorMessage(cause)}`;
 };
 
 const getErrorChain = (error: unknown) => {
@@ -87,6 +98,9 @@ export const getErrorTag = (error: unknown): string => {
 };
 
 export const getErrorMessage = (error: unknown): string => {
+	const contextualCollectionMessage = getCollectionDisplayMessage(error);
+	if (contextualCollectionMessage) return contextualCollectionMessage;
+
 	const chain = getErrorChain(error);
 
 	for (const entry of chain) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -419,7 +419,7 @@ const createApp = () => {
 			'/clear',
 			withHttpErrorHandling(
 				Effect.gen(function* () {
-					const result = yield* ServerServices.clearConfigResources;
+					const result = yield* ServerServices.clearResourceCaches;
 					return HttpServerResponse.jsonUnsafe(result);
 				})
 			)
@@ -460,9 +460,9 @@ export const startServer = async (options: StartServerOptions = {}): Promise<Ser
 	});
 
 	const resources = createResourcesService(config);
-	const collections = createCollectionsService({ config, resources });
+	const collections = createCollectionsService({ resources });
 	const agent = createAgentService(config);
-	const runtime = createServerRuntime({ config, collections, agent });
+	const runtime = createServerRuntime({ config, collections, agent, resources });
 	const appLayer = createApp();
 	const { handler, dispose } = HttpRouter.toWebHandler(appLayer, {
 		disableLogger: options.quiet === true

--- a/apps/server/src/resources/fs-utils.ts
+++ b/apps/server/src/resources/fs-utils.ts
@@ -1,0 +1,27 @@
+import { rm, stat } from 'node:fs/promises';
+
+export const pathExists = async (targetPath: string) => {
+	try {
+		await stat(targetPath);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const directoryExists = async (targetPath: string) => {
+	try {
+		const stats = await stat(targetPath);
+		return stats.isDirectory();
+	} catch {
+		return false;
+	}
+};
+
+export const cleanupDirectory = async (pathToRemove: string) => {
+	try {
+		await rm(pathToRemove, { recursive: true, force: true });
+	} catch {
+		return;
+	}
+};

--- a/apps/server/src/resources/helpers.ts
+++ b/apps/server/src/resources/helpers.ts
@@ -1,5 +1,19 @@
 import type { TaggedErrorOptions } from '../errors.ts';
 
+const LOCAL_RESOURCE_IGNORED_DIRECTORIES = new Set([
+	'.git',
+	'.turbo',
+	'.next',
+	'.svelte-kit',
+	'.vercel',
+	'.cache',
+	'coverage',
+	'dist',
+	'build',
+	'out',
+	'node_modules'
+]);
+
 export class ResourceError extends Error {
 	readonly _tag = 'ResourceError';
 	override readonly cause?: unknown;
@@ -15,4 +29,19 @@ export class ResourceError extends Error {
 
 export const resourceNameToKey = (name: string): string => {
 	return encodeURIComponent(name);
+};
+
+const normalizeRelativePath = (value: string) => value.split('\\').join('/');
+
+export const shouldIgnoreCommonImportedPath = (relativePath: string): boolean => {
+	const normalized = normalizeRelativePath(relativePath);
+	if (!normalized || normalized === '.') return false;
+	return normalized.split('/').includes('.git');
+};
+
+export const shouldIgnoreLocalImportedPath = (relativePath: string): boolean => {
+	const normalized = normalizeRelativePath(relativePath);
+	if (!normalized || normalized === '.') return false;
+	if (shouldIgnoreCommonImportedPath(normalized)) return true;
+	return normalized.split('/').some((segment) => LOCAL_RESOURCE_IGNORED_DIRECTORIES.has(segment));
 };

--- a/apps/server/src/resources/impls/git.process.test.ts
+++ b/apps/server/src/resources/impls/git.process.test.ts
@@ -1,0 +1,532 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { createAnonymousDirectoryKey, createResourcesService } from '../service.ts';
+import { setFilesystemLockTestHookForTests } from '../lock.ts';
+import {
+	getGitLockPath,
+	getGitMirrorPath,
+	getGitMirrorRepoPath,
+	getTmpCacheRoot
+} from '../layout.ts';
+import type { ResourceDefinition } from '../schema.ts';
+import { createConfigServiceMock, createStaleLockDirectory } from '../test-support.ts';
+import { logQueueMetrics, readStream, waitFor } from './test-fixtures/process-support.ts';
+
+const workerPath = path.join(import.meta.dir, 'test-fixtures', 'git-materialize-worker.ts');
+
+const runGit = async (
+	args: readonly string[],
+	options?: { cwd?: string; env?: Record<string, string | undefined> }
+) => {
+	const proc = Bun.spawn(['git', ...args], {
+		...(options?.cwd ? { cwd: options.cwd } : {}),
+		...(options?.env ? { env: { ...process.env, ...options.env } } : {}),
+		stdout: 'pipe',
+		stderr: 'pipe'
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		readStream(proc.stdout),
+		readStream(proc.stderr),
+		proc.exited
+	]);
+
+	if (exitCode !== 0) {
+		throw new Error(
+			`git ${args.join(' ')} failed with exit code ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`
+		);
+	}
+
+	return stdout.trim();
+};
+
+const pathExists = async (targetPath: string) => {
+	try {
+		await fs.stat(targetPath);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const createRealGitRemote = async (tempDir: string) => {
+	const bareRepoPath = path.join(tempDir, 'real-remote.git');
+	const seedRepoPath = path.join(tempDir, 'real-seed');
+	const homePath = path.join(tempDir, 'real-home');
+	const gitConfigPath = path.join(tempDir, 'real-gitconfig');
+	const remoteUrl = 'https://example.com/repo.git';
+	const redirectedUrl = pathToFileURL(bareRepoPath).href;
+	const gitEnv = {
+		HOME: homePath,
+		GIT_CONFIG_GLOBAL: gitConfigPath,
+		GIT_CONFIG_NOSYSTEM: '1'
+	};
+
+	await fs.mkdir(homePath, { recursive: true });
+	await Bun.write(
+		gitConfigPath,
+		`[url "${redirectedUrl}"]\n\tinsteadOf = ${remoteUrl}\n[init]\n\tdefaultBranch = main\n`
+	);
+
+	await runGit(['init', '--bare', bareRepoPath], { env: gitEnv });
+	await runGit(['init', seedRepoPath], { env: gitEnv });
+	await runGit(['config', 'user.name', 'BTCA Test'], { cwd: seedRepoPath, env: gitEnv });
+	await runGit(['config', 'user.email', 'btca@example.com'], { cwd: seedRepoPath, env: gitEnv });
+
+	await fs.mkdir(path.join(seedRepoPath, 'docs'), { recursive: true });
+	await Bun.write(path.join(seedRepoPath, 'README.md'), '# real repo\n');
+	await Bun.write(path.join(seedRepoPath, 'docs', 'guide.md'), 'real docs\n');
+	await runGit(['add', '.'], { cwd: seedRepoPath, env: gitEnv });
+	await runGit(['commit', '-m', 'initial'], { cwd: seedRepoPath, env: gitEnv });
+	await runGit(['remote', 'add', 'origin', bareRepoPath], { cwd: seedRepoPath, env: gitEnv });
+	await runGit(['push', '--set-upstream', 'origin', 'main'], { cwd: seedRepoPath, env: gitEnv });
+
+	return { remoteUrl, gitEnv };
+};
+
+const createFakeGitBinary = async (
+	tempDir: string,
+	args?: { sleepMs?: number; holdMutationsUntilRelease?: boolean }
+) => {
+	const binDir = path.join(tempDir, 'bin');
+	const logPath = path.join(tempDir, 'fake-git-log.jsonl');
+	const mutationRoot = path.join(tempDir, 'fake-git-mutation-locks');
+	const holdRoot = path.join(tempDir, 'fake-git-holds');
+	await fs.mkdir(binDir, { recursive: true });
+	await fs.mkdir(mutationRoot, { recursive: true });
+	await fs.mkdir(holdRoot, { recursive: true });
+
+	const scriptPath = path.join(binDir, 'git');
+	const script = `#!/usr/bin/env bun
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const logPath = process.env.BTCA_FAKE_GIT_LOG;
+const mutationRoot = process.env.BTCA_FAKE_GIT_MUTATION_ROOT;
+const holdRoot = process.env.BTCA_FAKE_GIT_HOLD_ROOT;
+const sleepMs = Number(process.env.BTCA_FAKE_GIT_SLEEP_MS ?? '0');
+const args = process.argv.slice(2);
+
+const log = async (event) => {
+  if (!logPath) return;
+  await fs.appendFile(logPath, JSON.stringify(event) + '\\n');
+};
+
+const maybeWaitForRelease = async (key) => {
+  if (!holdRoot) return;
+  const token = encodeURIComponent(key);
+  const startedPath = path.join(holdRoot, token + '.started');
+  const releasePath = path.join(holdRoot, token + '.release');
+  await fs.writeFile(startedPath, '');
+  while (!(await fs.stat(releasePath).catch(() => null))) {
+    await sleep(10);
+  }
+};
+
+const acquireMutationLock = async (key) => {
+  if (!mutationRoot) return async () => {};
+  const mutationLockPath = path.join(mutationRoot, encodeURIComponent(key) + '.lock');
+  const handle = await fs.open(mutationLockPath, 'wx').catch(() => null);
+  if (!handle) {
+    console.error('concurrent git mutation');
+    process.exit(1);
+  }
+  await handle.close();
+  return async () => {
+    await fs.rm(mutationLockPath, { force: true }).catch(() => undefined);
+  };
+};
+
+const repoPath = args[args.length - 1];
+if (!repoPath) process.exit(1);
+
+if (args[0] === 'clone') {
+  const branchIndex = args.indexOf('-b');
+  const branch = branchIndex >= 0 ? args[branchIndex + 1] : 'main';
+  const release = await acquireMutationLock(repoPath);
+  try {
+    await log({ cmd: 'clone', branch, repoPath });
+    if (sleepMs > 0) await sleep(sleepMs);
+    await maybeWaitForRelease(repoPath);
+    await fs.mkdir(path.join(repoPath, '.git'), { recursive: true });
+    await fs.mkdir(path.join(repoPath, 'docs'), { recursive: true });
+    await fs.writeFile(path.join(repoPath, 'README.md'), '# fake repo\\n');
+    await fs.writeFile(path.join(repoPath, 'docs', 'guide.md'), 'guide\\n');
+    await fs.writeFile(path.join(repoPath, '.fake-head'), 'fake-commit\\n');
+    await fs.writeFile(path.join(repoPath, '.fake-branch'), branch + '\\n');
+  } finally {
+    await release();
+  }
+  process.exit(0);
+}
+
+if (args[0] === 'fetch' || args[0] === 'reset') {
+  const cwd = process.cwd();
+  const release = await acquireMutationLock(cwd);
+  try {
+    await log({ cmd: args[0], cwd });
+    if (sleepMs > 0) await sleep(sleepMs);
+    await maybeWaitForRelease(cwd);
+    await fs.mkdir(path.join(cwd, '.git'), { recursive: true });
+    await fs.writeFile(path.join(cwd, '.fake-head'), 'fake-commit\\n');
+  } finally {
+    await release();
+  }
+  process.exit(0);
+}
+
+if (args[0] === 'sparse-checkout' || args[0] === 'checkout') {
+  await log({ cmd: args[0], cwd: process.cwd(), args });
+  process.exit(0);
+}
+
+if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+  const cwd = process.cwd();
+  const value = await fs.readFile(path.join(cwd, '.fake-head'), 'utf8').catch(() => 'fake-commit\\n');
+  process.stdout.write(value);
+  process.exit(0);
+}
+
+if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref' && args[2] === 'HEAD') {
+  const cwd = process.cwd();
+  const value = await fs.readFile(path.join(cwd, '.fake-branch'), 'utf8').catch(() => 'main\\n');
+  process.stdout.write(value);
+  process.exit(0);
+}
+
+await log({ cmd: 'unknown', args, cwd: process.cwd() });
+process.exit(0);
+`;
+
+	await Bun.write(scriptPath, script);
+	await fs.chmod(scriptPath, 0o755);
+
+	return {
+		binDir,
+		logPath,
+		mutationRoot,
+		...(args?.holdMutationsUntilRelease ? { holdRoot } : {}),
+		sleepMs: args?.sleepMs ?? 0
+	};
+};
+
+const runWorker = async (args: {
+	binDir?: string;
+	logPath?: string;
+	mutationRoot?: string;
+	holdRoot?: string;
+	sleepMs?: number;
+	env?: Record<string, string | undefined>;
+	payload: Record<string, unknown>;
+}) => {
+	const proc = Bun.spawn([process.execPath, workerPath], {
+		cwd: path.join(import.meta.dir, '..', '..', '..', '..', '..'),
+		env: {
+			...process.env,
+			...(args.binDir ? { PATH: `${args.binDir}:${process.env.PATH ?? ''}` } : {}),
+			...(args.logPath ? { BTCA_FAKE_GIT_LOG: args.logPath } : {}),
+			...(args.mutationRoot ? { BTCA_FAKE_GIT_MUTATION_ROOT: args.mutationRoot } : {}),
+			...(args.holdRoot ? { BTCA_FAKE_GIT_HOLD_ROOT: args.holdRoot } : {}),
+			...(typeof args.sleepMs === 'number' ? { BTCA_FAKE_GIT_SLEEP_MS: String(args.sleepMs) } : {}),
+			...(args.env ?? {}),
+			BTCA_WORKER_PAYLOAD: JSON.stringify({
+				...(args.binDir ? { gitBinDir: args.binDir } : {}),
+				...args.payload
+			})
+		},
+		stdout: 'pipe',
+		stderr: 'pipe'
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		readStream(proc.stdout),
+		readStream(proc.stderr),
+		proc.exited
+	]);
+
+	return { stdout, stderr, exitCode };
+};
+
+describe('git process locking', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-git-process-'));
+	});
+
+	afterEach(async () => {
+		setFilesystemLockTestHookForTests();
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it('serializes same named git mirror across concurrent subprocesses', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const fakeGit = await createFakeGitBinary(tempDir, { sleepMs: 120 });
+
+		const payload = {
+			resourcesDirectory,
+			name: 'docs',
+			url: 'https://example.com/repo.git',
+			branch: 'main',
+			repoSubPaths: ['docs']
+		};
+
+		const startedAt = performance.now();
+		const [first, second] = await Promise.all([
+			(async () => {
+				const workerStartedAt = performance.now();
+				const result = await runWorker({ ...fakeGit, payload });
+				return { ...result, elapsedMs: performance.now() - workerStartedAt };
+			})(),
+			(async () => {
+				const workerStartedAt = performance.now();
+				const result = await runWorker({ ...fakeGit, payload });
+				return { ...result, elapsedMs: performance.now() - workerStartedAt };
+			})()
+		]);
+		logQueueMetrics('git.named.fake.same-resource', {
+			totalElapsedMs: performance.now() - startedAt,
+			workerElapsedMs: [first.elapsedMs, second.elapsedMs]
+		});
+
+		expect(first.exitCode).toBe(0);
+		expect(second.exitCode).toBe(0);
+		expect(first.stderr).not.toContain('concurrent git mutation');
+		expect(second.stderr).not.toContain('concurrent git mutation');
+	});
+
+	it('serializes same named git mirror across concurrent subprocesses with a real local bare repo', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const remote = await createRealGitRemote(tempDir);
+		const payload = {
+			resourcesDirectory,
+			name: 'docs',
+			url: remote.remoteUrl,
+			branch: 'main',
+			repoSubPaths: ['docs']
+		};
+
+		const startedAt = performance.now();
+		const [first, second] = await Promise.all([
+			(async () => {
+				const workerStartedAt = performance.now();
+				const result = await runWorker({ env: remote.gitEnv, payload });
+				return { ...result, elapsedMs: performance.now() - workerStartedAt };
+			})(),
+			(async () => {
+				const workerStartedAt = performance.now();
+				const result = await runWorker({ env: remote.gitEnv, payload });
+				return { ...result, elapsedMs: performance.now() - workerStartedAt };
+			})()
+		]);
+		logQueueMetrics('git.named.real.same-resource', {
+			totalElapsedMs: performance.now() - startedAt,
+			workerElapsedMs: [first.elapsedMs, second.elapsedMs]
+		});
+
+		expect(first.exitCode).toBe(0);
+		expect(second.exitCode).toBe(0);
+		expect(first.stderr).toBe('');
+		expect(second.stderr).toBe('');
+		expect(
+			await Bun.file(
+				path.join(resourcesDirectory, '.git-mirrors', 'docs', 'repo', 'docs', 'guide.md')
+			).exists()
+		).toBe(true);
+	});
+
+	it('uses a unique temp directory for each anonymous git resource', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const fakeGit = await createFakeGitBinary(tempDir);
+		const url = 'https://example.com/repo.git';
+		const anonymousKey = createAnonymousDirectoryKey(url);
+
+		const payload = {
+			resourcesDirectory,
+			name: `anonymous:${url}`,
+			url,
+			branch: 'main',
+			ephemeral: true,
+			localDirectoryKey: anonymousKey
+		};
+
+		const [first, second] = await Promise.all([
+			runWorker({ ...fakeGit, payload }),
+			runWorker({ ...fakeGit, payload })
+		]);
+
+		expect(first.exitCode).toBe(0);
+		expect(second.exitCode).toBe(0);
+
+		const cloneTargets = (await Bun.file(fakeGit.logPath).text())
+			.trim()
+			.split('\n')
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as { cmd: string; repoPath?: string })
+			.filter((entry) => entry.cmd === 'clone' && typeof entry.repoPath === 'string')
+			.map((entry) => entry.repoPath as string);
+
+		expect(new Set(cloneTargets).size).toBeGreaterThanOrEqual(2);
+		for (const cloneTarget of cloneTargets) {
+			expect(cloneTarget).toContain(
+				`${path.join(getTmpCacheRoot(resourcesDirectory), `btca-anon-git-${anonymousKey}-`)}`
+			);
+		}
+	});
+
+	it('clear waits for an in-flight anonymous git materialization before removing temp dirs', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const fakeGit = await createFakeGitBinary(tempDir, { holdMutationsUntilRelease: true });
+		const url = 'https://example.com/repo.git';
+		const anonymousKey = createAnonymousDirectoryKey(url);
+		const payload = {
+			resourcesDirectory,
+			name: `anonymous:${url}`,
+			url,
+			branch: 'main',
+			ephemeral: true,
+			localDirectoryKey: anonymousKey
+		};
+		let clearBlocked = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (
+				event.phase === 'waiting-on-live-lock' &&
+				event.lockPath === getGitLockPath(resourcesDirectory, anonymousKey) &&
+				event.label === `clear.git.${anonymousKey}`
+			) {
+				clearBlocked = true;
+			}
+		});
+
+		const workerPromise = runWorker({ ...fakeGit, payload });
+
+		let cloneStartedEntry = '';
+		await waitFor(async () => {
+			const entries = await fs.readdir(fakeGit.holdRoot!).catch(() => []);
+			cloneStartedEntry = entries.find((entry) => entry.endsWith('.started')) ?? '';
+			return cloneStartedEntry.length > 0;
+		});
+		const holdToken = cloneStartedEntry.slice(0, -'.started'.length);
+		const cloneTarget = decodeURIComponent(holdToken);
+		const cloneReleasePath = path.join(fakeGit.holdRoot!, `${holdToken}.release`);
+
+		const service = createResourcesService(
+			createConfigServiceMock({
+				resourcesDirectory,
+				resources: []
+			})
+		);
+
+		const clearPromise = service.clearCachesPromise();
+		await waitFor(() => clearBlocked);
+		expect(await pathExists(cloneTarget)).toBe(true);
+
+		await Bun.write(cloneReleasePath, '');
+
+		const workerResult = await workerPromise;
+		const clearResult = await clearPromise;
+
+		expect(workerResult.exitCode).toBe(0);
+		expect(clearResult.cleared).toBeGreaterThanOrEqual(1);
+		expect(await pathExists(cloneTarget)).toBe(false);
+	});
+
+	it('clear waits for an in-flight named mirror materialization even before the mirror exists', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const fakeGit = await createFakeGitBinary(tempDir, { holdMutationsUntilRelease: true });
+		const payload = {
+			resourcesDirectory,
+			name: 'docs',
+			url: 'https://example.com/repo.git',
+			branch: 'main'
+		};
+		const mirrorPath = getGitMirrorPath(resourcesDirectory, 'docs');
+		const mirrorRepoPath = getGitMirrorRepoPath(resourcesDirectory, 'docs');
+		const holdToken = encodeURIComponent(mirrorRepoPath);
+		const cloneStartedPath = path.join(fakeGit.holdRoot!, `${holdToken}.started`);
+		const cloneReleasePath = path.join(fakeGit.holdRoot!, `${holdToken}.release`);
+		let clearBlocked = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (
+				event.phase === 'waiting-on-live-lock' &&
+				event.lockPath === getGitLockPath(resourcesDirectory, 'docs') &&
+				event.label === 'clear.git.docs'
+			) {
+				clearBlocked = true;
+			}
+		});
+
+		const workerPromise = runWorker({ ...fakeGit, payload });
+		await waitFor(() => pathExists(cloneStartedPath));
+		expect(await Bun.file(mirrorPath).exists()).toBe(false);
+
+		const service = createResourcesService(
+			createConfigServiceMock({
+				resourcesDirectory,
+				resources: [
+					{
+						type: 'git',
+						name: 'docs',
+						url: 'https://example.com/repo.git',
+						branch: 'main'
+					}
+				]
+			})
+		);
+
+		const clearPromise = service.clearCachesPromise();
+		await waitFor(() => clearBlocked);
+		await Bun.write(cloneReleasePath, '');
+
+		const clearResult = await clearPromise;
+		const workerResult = await workerPromise;
+
+		expect(workerResult.exitCode).toBe(0);
+		expect(clearResult.cleared).toBeGreaterThanOrEqual(1);
+		expect(await Bun.file(mirrorPath).exists()).toBe(false);
+	});
+
+	it('named git materialization recovers after a stale clear.lock instead of hanging', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const fakeGit = await createFakeGitBinary(tempDir);
+		await createStaleLockDirectory(path.join(resourcesDirectory, '.resource-locks', 'clear.lock'));
+
+		const workerResult = await runWorker({
+			...fakeGit,
+			payload: {
+				resourcesDirectory,
+				name: 'docs',
+				url: 'https://example.com/repo.git',
+				branch: 'main'
+			}
+		});
+
+		expect(workerResult.exitCode).toBe(0);
+		expect(workerResult.stderr).toBe('');
+	});
+
+	it('named git materialization recovers after a stale clear.lock with a real local bare repo', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const remote = await createRealGitRemote(tempDir);
+		await createStaleLockDirectory(path.join(resourcesDirectory, '.resource-locks', 'clear.lock'));
+
+		const workerResult = await runWorker({
+			env: remote.gitEnv,
+			payload: {
+				resourcesDirectory,
+				name: 'docs',
+				url: remote.remoteUrl,
+				branch: 'main',
+				repoSubPaths: ['docs']
+			}
+		});
+
+		expect(workerResult.exitCode).toBe(0);
+		expect(workerResult.stderr).toBe('');
+	});
+});

--- a/apps/server/src/resources/impls/git.test.ts
+++ b/apps/server/src/resources/impls/git.test.ts
@@ -1,10 +1,339 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import os from 'node:os';
+import path from 'node:path';
 
-import { loadGitResource } from './git.ts';
+import { loadGitResource, type GitResourceDeps } from './git.ts';
+import { getTmpCacheRoot } from '../layout.ts';
+import { setFilesystemLockTestHookForTests } from '../lock.ts';
 import type { BtcaGitResourceArgs } from '../types.ts';
+import {
+	createVirtualFs,
+	disposeVirtualFs,
+	existsInVirtualFs,
+	readVirtualFsFile
+} from '../../vfs/virtual-fs.ts';
+
+type MockCommandLogEntry = {
+	readonly cmd: string;
+	readonly repoPath?: string;
+	readonly branch?: string;
+	readonly repoUrl?: string;
+	readonly repoSubPaths?: readonly string[];
+};
+
+const pathExists = async (targetPath: string) => {
+	try {
+		await fs.stat(targetPath);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const streamFromString = (value: string) =>
+	new ReadableStream<Uint8Array>({
+		start(controller) {
+			if (value.length > 0) controller.enqueue(new TextEncoder().encode(value));
+			controller.close();
+		}
+	});
+
+const getMockFilesForUrl = (repoUrl: string) => ({
+	'README.md': repoUrl.includes('repo-b') ? '# repo-b\n' : '# repo-a\n',
+	'docs/guide.md': repoUrl.includes('repo-b') ? 'repo-b docs\n' : 'repo-a docs\n',
+	'src/runtime.js': repoUrl.includes('repo-b')
+		? `export const runtime = 'repo-b';\n`
+		: `export const runtime = 'repo-a';\n`
+});
+
+const mockStatePaths = (repoPath: string) => ({
+	origin: path.join(repoPath, '.btca-origin'),
+	branch: path.join(repoPath, '.btca-branch'),
+	head: path.join(repoPath, '.btca-head'),
+	sparse: path.join(repoPath, '.git', 'info', 'sparse-checkout')
+});
+
+const writeCommandLog = async (logPath: string, entry: MockCommandLogEntry) => {
+	await fs.appendFile(logPath, `${JSON.stringify(entry)}\n`);
+};
+
+const writeRepoState = async (repoPath: string, repoUrl: string, branch: string) => {
+	const statePaths = mockStatePaths(repoPath);
+	await fs.mkdir(path.join(repoPath, '.git', 'info'), { recursive: true });
+	await fs.writeFile(path.join(repoPath, '.git', 'config'), '[mock]\n');
+	await fs.writeFile(statePaths.origin, repoUrl);
+	await fs.writeFile(statePaths.branch, branch);
+	await fs.writeFile(statePaths.head, `commit:${repoUrl}:${branch}\n`);
+};
+
+const readRepoOrigin = async (repoPath: string) =>
+	await Bun.file(mockStatePaths(repoPath).origin)
+		.text()
+		.catch(() => '');
+
+const readRepoBranch = async (repoPath: string) =>
+	await Bun.file(mockStatePaths(repoPath).branch)
+		.text()
+		.catch(() => '');
+
+const removeWorkingTreeFiles = async (repoPath: string) => {
+	let entries: string[] = [];
+	try {
+		entries = await fs.readdir(repoPath);
+	} catch {
+		entries = [];
+	}
+
+	for (const entry of entries) {
+		if (entry === '.git' || entry.startsWith('.btca-')) continue;
+		await fs.rm(path.join(repoPath, entry), { recursive: true, force: true });
+	}
+};
+
+const applyWorkingTree = async (
+	repoPath: string,
+	repoUrl: string,
+	repoSubPaths: readonly string[] | null
+) => {
+	await removeWorkingTreeFiles(repoPath);
+	const allFiles = getMockFilesForUrl(repoUrl);
+	const entries = Object.entries(allFiles).filter(([relativePath]) => {
+		if (!repoSubPaths || repoSubPaths.length === 0) return true;
+		return repoSubPaths.some(
+			(repoSubPath) => relativePath === repoSubPath || relativePath.startsWith(`${repoSubPath}/`)
+		);
+	});
+
+	for (const [relativePath, content] of entries) {
+		const targetPath = path.join(repoPath, relativePath);
+		await fs.mkdir(path.dirname(targetPath), { recursive: true });
+		await fs.writeFile(targetPath, content);
+	}
+
+	const sparseFilePath = mockStatePaths(repoPath).sparse;
+	if (repoSubPaths && repoSubPaths.length > 0) {
+		await fs.mkdir(path.dirname(sparseFilePath), { recursive: true });
+		await fs.writeFile(sparseFilePath, `${repoSubPaths.join('\n')}\n`);
+	} else {
+		await fs.rm(sparseFilePath, { force: true });
+	}
+};
+
+const createGitSpawnMock = (logPath: string) =>
+	((...spawnArgs: Parameters<typeof Bun.spawn>) => {
+		const [command, options] = spawnArgs;
+		const commandArgs = Array.isArray(command) ? command : [command];
+		const gitArgs = commandArgs.slice(1);
+
+		const exited = (async () => {
+			const cwd = options?.cwd;
+
+			if (gitArgs[0] === 'clone') {
+				const repoPath = gitArgs.at(-1);
+				const repoUrl = gitArgs.at(-2);
+				const branchIndex = gitArgs.indexOf('-b');
+				const branch = branchIndex >= 0 ? gitArgs[branchIndex + 1] : 'main';
+				const sparseClone = gitArgs.includes('--sparse');
+				if (!repoPath || !repoUrl) return 1;
+				const resolvedBranch = branch ?? 'main';
+
+				await writeCommandLog(logPath, {
+					cmd: 'clone',
+					repoPath,
+					branch: resolvedBranch,
+					repoUrl
+				});
+				await writeRepoState(repoPath, repoUrl, resolvedBranch);
+				await applyWorkingTree(repoPath, repoUrl, sparseClone ? ['__pending_sparse__'] : null);
+				if (sparseClone) {
+					await removeWorkingTreeFiles(repoPath);
+				}
+				return 0;
+			}
+
+			if (gitArgs[0] === 'fetch') {
+				await writeCommandLog(logPath, { cmd: 'fetch', repoPath: cwd ?? undefined });
+				return 0;
+			}
+
+			if (gitArgs[0] === 'reset') {
+				await writeCommandLog(logPath, { cmd: 'reset', repoPath: cwd ?? undefined });
+				return 0;
+			}
+
+			if (gitArgs[0] === 'sparse-checkout' && gitArgs[1] === 'set') {
+				if (!cwd) return 1;
+				const repoUrl = await readRepoOrigin(cwd);
+				const repoSubPaths = gitArgs.slice(2);
+				await writeCommandLog(logPath, {
+					cmd: 'sparse-checkout-set',
+					repoPath: cwd,
+					repoSubPaths
+				});
+				await applyWorkingTree(cwd, repoUrl, repoSubPaths);
+				return 0;
+			}
+
+			if (gitArgs[0] === 'sparse-checkout' && gitArgs[1] === 'disable') {
+				if (!cwd) return 1;
+				const repoUrl = await readRepoOrigin(cwd);
+				await writeCommandLog(logPath, { cmd: 'sparse-checkout-disable', repoPath: cwd });
+				await applyWorkingTree(cwd, repoUrl, null);
+				return 0;
+			}
+
+			if (gitArgs[0] === 'checkout') {
+				await writeCommandLog(logPath, { cmd: 'checkout', repoPath: cwd ?? undefined });
+				return 0;
+			}
+
+			if (gitArgs[0] === 'rev-parse' && gitArgs[1] === 'HEAD' && cwd) {
+				return 0;
+			}
+
+			if (
+				gitArgs[0] === 'rev-parse' &&
+				gitArgs[1] === '--abbrev-ref' &&
+				gitArgs[2] === 'HEAD' &&
+				cwd
+			) {
+				return 0;
+			}
+
+			if (gitArgs[0] === 'rev-parse' && gitArgs[1] === '--is-inside-work-tree') {
+				return cwd && (await pathExists(path.join(cwd, '.git'))) ? 0 : 128;
+			}
+
+			if (gitArgs[0] === 'remote' && gitArgs[1] === 'get-url' && gitArgs[2] === 'origin') {
+				return cwd && (await pathExists(mockStatePaths(cwd).origin)) ? 0 : 1;
+			}
+
+			return 0;
+		})();
+
+		const stdout = (async () => {
+			const cwd = options?.cwd;
+			if (gitArgs[0] === 'rev-parse' && gitArgs[1] === 'HEAD' && cwd) {
+				return await Bun.file(mockStatePaths(cwd).head)
+					.text()
+					.catch(() => 'fake-commit\n');
+			}
+
+			if (
+				gitArgs[0] === 'rev-parse' &&
+				gitArgs[1] === '--abbrev-ref' &&
+				gitArgs[2] === 'HEAD' &&
+				cwd
+			) {
+				const branch = await readRepoBranch(cwd);
+				return branch.length > 0 ? branch : 'main';
+			}
+
+			if (gitArgs[0] === 'rev-parse' && gitArgs[1] === '--is-inside-work-tree') {
+				return 'true\n';
+			}
+
+			if (gitArgs[0] === 'remote' && gitArgs[1] === 'get-url' && gitArgs[2] === 'origin' && cwd) {
+				const origin = await readRepoOrigin(cwd);
+				return origin.length > 0 ? origin : '';
+			}
+
+			return '';
+		})();
+
+		return {
+			stderr: streamFromString(''),
+			exited,
+			stdout: new ReadableStream<Uint8Array>({
+				async start(controller) {
+					const value = await stdout;
+					if (value.length > 0) controller.enqueue(new TextEncoder().encode(value));
+					controller.close();
+				}
+			})
+		} as unknown as ReturnType<typeof Bun.spawn>;
+	}) as typeof Bun.spawn;
+
+const createGitSpawnWithLsRemoteResponses = (
+	logPath: string,
+	responses: readonly { exitCode: number; stderr?: string; stdout?: string }[]
+) => {
+	const baseSpawn = createGitSpawnMock(logPath);
+	let responseIndex = 0;
+
+	return ((...spawnArgs: Parameters<typeof Bun.spawn>) => {
+		const [command] = spawnArgs;
+		const commandArgs = Array.isArray(command) ? command : [command];
+		const gitArgs = commandArgs.slice(1);
+
+		if (gitArgs[0] === 'ls-remote') {
+			const response = responses[responseIndex] ??
+				responses.at(-1) ?? {
+					exitCode: 0,
+					stdout: 'deadbeef\trefs/heads/main\n'
+				};
+			responseIndex += 1;
+
+			return {
+				stderr: streamFromString(response.stderr ?? ''),
+				exited: Promise.resolve(response.exitCode),
+				stdout: streamFromString(response.stdout ?? '')
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}
+
+		return baseSpawn(...spawnArgs);
+	}) as typeof Bun.spawn;
+};
+
+const readCommandLog = async (logPath: string) => {
+	if (!(await pathExists(logPath))) return [];
+	return (await Bun.file(logPath).text())
+		.trim()
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as MockCommandLogEntry);
+};
+
+const materializeResource = async (
+	resource: Awaited<ReturnType<typeof loadGitResource>>,
+	destinationPath: string
+) => {
+	const vfsId = createVirtualFs();
+	try {
+		const result = await resource.materializeIntoVirtualFs({ destinationPath, vfsId });
+		return { result, vfsId };
+	} catch (cause) {
+		disposeVirtualFs(vfsId);
+		throw cause;
+	}
+};
+
+const createGitTestDeps = (
+	logPath: string,
+	overrides?: Partial<GitResourceDeps>
+): Partial<GitResourceDeps> => ({
+	spawn: createGitSpawnMock(logPath),
+	...(overrides ?? {})
+});
+
+const writeLiveClearLock = async (lockPath: string) => {
+	await fs.mkdir(lockPath, { recursive: true });
+	await Bun.write(
+		path.join(lockPath, 'owner.json'),
+		JSON.stringify(
+			{
+				pid: process.pid,
+				token: 'live-clear-lock',
+				label: 'resources.clear',
+				startedAt: new Date().toISOString()
+			},
+			null,
+			2
+		)
+	);
+	await Bun.write(path.join(lockPath, 'heartbeat'), '');
+};
 
 describe('Git Resource', () => {
 	let testDir: string;
@@ -14,106 +343,493 @@ describe('Git Resource', () => {
 	});
 
 	afterEach(async () => {
+		setFilesystemLockTestHookForTests();
 		await fs.rm(testDir, { recursive: true, force: true });
 	});
 
-	describe('loadGitResource', () => {
-		describe.skipIf(!process.env.BTCA_RUN_INTEGRATION_TESTS)('integration (network)', () => {
-			it('clones a git repository', async () => {
-				const args: BtcaGitResourceArgs = {
+	it('throws error for invalid git URL', async () => {
+		const args: BtcaGitResourceArgs = {
+			type: 'git',
+			name: 'invalid-url',
+			url: 'not-a-valid-url',
+			branch: 'main',
+			repoSubPaths: [],
+			resourcesDirectoryPath: testDir,
+			specialAgentInstructions: '',
+			quiet: true
+		};
+
+		expect(loadGitResource(args)).rejects.toThrow('Git URL must be a valid HTTPS URL');
+	});
+
+	it('throws error for invalid branch name', async () => {
+		const args: BtcaGitResourceArgs = {
+			type: 'git',
+			name: 'invalid-branch',
+			url: 'https://github.com/test/repo',
+			branch: 'invalid branch name!',
+			repoSubPaths: [],
+			resourcesDirectoryPath: testDir,
+			specialAgentInstructions: '',
+			quiet: true
+		};
+
+		expect(loadGitResource(args)).rejects.toThrow('Branch name must contain only');
+	});
+
+	it('throws error for path traversal attempt', async () => {
+		const args: BtcaGitResourceArgs = {
+			type: 'git',
+			name: 'path-traversal',
+			url: 'https://github.com/test/repo',
+			branch: 'main',
+			repoSubPaths: ['../../../etc'],
+			resourcesDirectoryPath: testDir,
+			specialAgentInstructions: '',
+			quiet: true
+		};
+
+		expect(loadGitResource(args)).rejects.toThrow('path traversal');
+	});
+
+	it('imports named git repos into the VFS and excludes .git internals', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const resource = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: [],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+
+		const { vfsId } = await materializeResource(resource, '/docs');
+		try {
+			expect(await existsInVirtualFs('/docs/README.md', vfsId)).toBe(true);
+			expect(await existsInVirtualFs('/docs/.git/config', vfsId)).toBe(false);
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
+	});
+
+	it('reclones a named mirror when the configured origin URL changes', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const first = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: [],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+		const firstMaterialized = await materializeResource(first, '/docs-a');
+		disposeVirtualFs(firstMaterialized.vfsId);
+
+		const second = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-b.git',
+				branch: 'main',
+				repoSubPaths: [],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+		const { vfsId } = await materializeResource(second, '/docs-b');
+		try {
+			expect(await readVirtualFsFile('/docs-b/README.md', vfsId)).toContain('repo-b');
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
+
+		const cloneCount = (await readCommandLog(logPath)).filter(
+			(entry) => entry.cmd === 'clone'
+		).length;
+		expect(cloneCount).toBe(2);
+	});
+
+	it('reclones a named mirror when the existing directory is not a valid git working tree', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const mirrorPath = path.join(testDir, '.git-mirrors', 'docs', 'repo');
+		await fs.mkdir(mirrorPath, { recursive: true });
+		await fs.writeFile(path.join(mirrorPath, 'README.md'), 'broken mirror\n');
+
+		const resource = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: [],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+
+		const { vfsId } = await materializeResource(resource, '/docs');
+		try {
+			expect(await readVirtualFsFile('/docs/README.md', vfsId)).toContain('repo-a');
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
+
+		const cloneCount = (await readCommandLog(logPath)).filter(
+			(entry) => entry.cmd === 'clone'
+		).length;
+		expect(cloneCount).toBe(1);
+	});
+
+	it('disables sparse-checkout when a named resource transitions to full-repo mode', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const sparseResource = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: ['docs'],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+
+		const sparseMaterialized = await materializeResource(sparseResource, '/docs-sparse');
+		try {
+			expect(await existsInVirtualFs('/docs-sparse/docs/guide.md', sparseMaterialized.vfsId)).toBe(
+				true
+			);
+			expect(await existsInVirtualFs('/docs-sparse/README.md', sparseMaterialized.vfsId)).toBe(
+				false
+			);
+		} finally {
+			disposeVirtualFs(sparseMaterialized.vfsId);
+		}
+
+		const fullResource = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: [],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+		const fullMaterialized = await materializeResource(fullResource, '/docs-full');
+		try {
+			expect(await existsInVirtualFs('/docs-full/README.md', fullMaterialized.vfsId)).toBe(true);
+			expect(await existsInVirtualFs('/docs-full/src/runtime.js', fullMaterialized.vfsId)).toBe(
+				true
+			);
+		} finally {
+			disposeVirtualFs(fullMaterialized.vfsId);
+		}
+
+		const commandLog = await readCommandLog(logPath);
+		expect(commandLog.some((entry) => entry.cmd === 'sparse-checkout-disable')).toBe(true);
+	});
+
+	it('fails loudly when a repoSubPath is missing on first materialization', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const resource = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: ['missing'],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+
+		await expect(materializeResource(resource, '/docs')).rejects.toThrow(
+			'Path not found: "missing"'
+		);
+	});
+
+	it('fails loudly when a repoSubPath becomes missing after mirror reconcile', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const initial = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: ['docs'],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+		const initialMaterialized = await materializeResource(initial, '/docs-initial');
+		disposeVirtualFs(initialMaterialized.vfsId);
+
+		const updated = await loadGitResource(
+			{
+				type: 'git',
+				name: 'docs',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: ['missing'],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			gitDeps
+		);
+
+		await expect(materializeResource(updated, '/docs-updated')).rejects.toThrow(
+			'Path not found: "missing"'
+		);
+	});
+
+	it('re-waits on clear.lock before retrying named git materialization after post-acquire clear detection', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const resourceLockPath = path.join(testDir, '.resource-locks', 'git.docs.lock');
+		const clearLockPath = path.join(testDir, '.resource-locks', 'clear.lock');
+		let gitLockAcquireCount = 0;
+		let injectedClearLock = false;
+		let sawRetryAfterClear = false;
+
+		setFilesystemLockTestHookForTests(async (event) => {
+			if (
+				event.phase === 'clear-aware-resource-lock-acquired' &&
+				event.resourceLockPath === resourceLockPath
+			) {
+				gitLockAcquireCount += 1;
+				if (!injectedClearLock) {
+					injectedClearLock = true;
+					await writeLiveClearLock(clearLockPath);
+				}
+			}
+
+			if (
+				event.phase === 'clear-aware-retry-after-clear' &&
+				event.resourceLockPath === resourceLockPath &&
+				injectedClearLock
+			) {
+				sawRetryAfterClear = true;
+				await fs.rm(clearLockPath, { recursive: true, force: true });
+			}
+		});
+
+		try {
+			const resource = await loadGitResource(
+				{
 					type: 'git',
-					name: 'test-repo',
-					url: 'https://github.com/honojs/hono',
-					branch: 'main',
-					repoSubPaths: ['docs'],
-					resourcesDirectoryPath: testDir,
-					specialAgentInstructions: 'Test notes',
-					quiet: true
-				};
-
-				const resource = await loadGitResource(args);
-
-				expect(resource._tag).toBe('fs-based');
-				expect(resource.name).toBe('test-repo');
-				expect(resource.type).toBe('git');
-				expect(resource.repoSubPaths).toEqual(['docs']);
-				expect(resource.specialAgentInstructions).toBe('Test notes');
-
-				const resourcePath = await resource.getAbsoluteDirectoryPath();
-				expect(resourcePath).toBe(path.join(testDir, 'test-repo'));
-
-				const stat = await fs.stat(resourcePath);
-				expect(stat.isDirectory()).toBe(true);
-
-				const gitDir = await fs.stat(path.join(resourcePath, '.git'));
-				expect(gitDir.isDirectory()).toBe(true);
-			}, 30000);
-
-			it('updates an existing git repository', async () => {
-				const args: BtcaGitResourceArgs = {
-					type: 'git',
-					name: 'update-test',
-					url: 'https://github.com/honojs/hono',
+					name: 'docs',
+					url: 'https://example.com/repo-a.git',
 					branch: 'main',
 					repoSubPaths: [],
 					resourcesDirectoryPath: testDir,
 					specialAgentInstructions: '',
 					quiet: true
-				};
+				},
+				gitDeps
+			);
 
-				await loadGitResource(args);
-				const resource = await loadGitResource(args);
+			const { vfsId } = await materializeResource(resource, '/docs');
+			try {
+				expect(await readVirtualFsFile('/docs/README.md', vfsId)).toContain('repo-a');
+			} finally {
+				disposeVirtualFs(vfsId);
+			}
+		} finally {
+			setFilesystemLockTestHookForTests();
+		}
 
-				expect(resource.name).toBe('update-test');
-				const resourcePath = await resource.getAbsoluteDirectoryPath();
-				const stat = await fs.stat(resourcePath);
-				expect(stat.isDirectory()).toBe(true);
-			}, 60000);
-		});
+		expect(sawRetryAfterClear).toBe(true);
+		expect(gitLockAcquireCount).toBe(2);
+	});
 
-		it('throws error for invalid git URL', async () => {
-			const args: BtcaGitResourceArgs = {
+	it('cleans up anonymous temp checkouts after repeated materialization', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath);
+
+		const resource = await loadGitResource(
+			{
 				type: 'git',
-				name: 'invalid-url',
-				url: 'not-a-valid-url',
+				name: 'anonymous:https://example.com/repo-a.git',
+				url: 'https://example.com/repo-a.git',
 				branch: 'main',
 				repoSubPaths: [],
 				resourcesDirectoryPath: testDir,
 				specialAgentInstructions: '',
-				quiet: true
-			};
+				quiet: true,
+				ephemeral: true
+			},
+			gitDeps
+		);
 
-			expect(loadGitResource(args)).rejects.toThrow('Git URL must be a valid HTTPS URL');
+		const firstMaterialized = await materializeResource(resource, '/anonymous-first');
+		disposeVirtualFs(firstMaterialized.vfsId);
+
+		const [firstCloneTarget] = (await readCommandLog(logPath))
+			.filter((entry) => entry.cmd === 'clone')
+			.map((entry) => entry.repoPath as string);
+		expect(firstCloneTarget).toBeDefined();
+		expect(firstCloneTarget).toContain(
+			`${getTmpCacheRoot(testDir)}${path.sep}btca-anon-git-anonymous%3Ahttps%3A%2F%2Fexample.com%2Frepo-a.git-`
+		);
+		expect(await pathExists(firstCloneTarget!)).toBe(true);
+
+		const secondMaterialized = await materializeResource(resource, '/anonymous-second');
+		disposeVirtualFs(secondMaterialized.vfsId);
+
+		const cloneTargets = (await readCommandLog(logPath))
+			.filter((entry) => entry.cmd === 'clone')
+			.map((entry) => entry.repoPath as string);
+		expect(cloneTargets).toHaveLength(2);
+		expect(await pathExists(cloneTargets[0]!)).toBe(false);
+		expect(await pathExists(cloneTargets[1]!)).toBe(true);
+
+		await resource.cleanup?.();
+		expect(await pathExists(cloneTargets[1]!)).toBe(false);
+	});
+
+	it('tries the next anonymous fallback branch when ls-remote reports a missing branch', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath, {
+			spawn: createGitSpawnWithLsRemoteResponses(logPath, [
+				{ exitCode: 2 },
+				{ exitCode: 0, stdout: 'deadbeef\trefs/heads/master\n' }
+			])
 		});
 
-		it('throws error for invalid branch name', async () => {
-			const args: BtcaGitResourceArgs = {
+		const resource = await loadGitResource(
+			{
 				type: 'git',
-				name: 'invalid-branch',
-				url: 'https://github.com/test/repo',
-				branch: 'invalid branch name!',
+				name: 'anonymous:https://example.com/repo-a.git',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
 				repoSubPaths: [],
 				resourcesDirectoryPath: testDir,
 				specialAgentInstructions: '',
-				quiet: true
-			};
+				quiet: true,
+				ephemeral: true
+			},
+			gitDeps
+		);
 
-			expect(loadGitResource(args)).rejects.toThrow('Branch name must contain only');
+		const { result, vfsId } = await materializeResource(resource, '/anonymous-master');
+		try {
+			expect(result.metadata.branch).toBe('master');
+			expect(await readVirtualFsFile('/anonymous-master/README.md', vfsId)).toContain('repo-a');
+		} finally {
+			disposeVirtualFs(vfsId);
+			await resource.cleanup?.();
+		}
+
+		const cloneEntries = (await readCommandLog(logPath)).filter((entry) => entry.cmd === 'clone');
+		expect(cloneEntries).toHaveLength(1);
+		expect(cloneEntries[0]?.branch).toBe('master');
+	});
+
+	it('fails immediately when anonymous branch probing hits a non-branch git error', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath, {
+			spawn: createGitSpawnWithLsRemoteResponses(logPath, [
+				{
+					exitCode: 128,
+					stderr: 'fatal: Authentication failed for https://example.com/repo-a.git'
+				}
+			])
 		});
 
-		it('throws error for path traversal attempt', async () => {
-			const args: BtcaGitResourceArgs = {
+		const resource = await loadGitResource(
+			{
 				type: 'git',
-				name: 'path-traversal',
-				url: 'https://github.com/test/repo',
+				name: 'anonymous:https://example.com/repo-a.git',
+				url: 'https://example.com/repo-a.git',
 				branch: 'main',
-				repoSubPaths: ['../../../etc'],
+				repoSubPaths: [],
 				resourcesDirectoryPath: testDir,
 				specialAgentInstructions: '',
-				quiet: true
-			};
+				quiet: true,
+				ephemeral: true
+			},
+			gitDeps
+		);
 
-			expect(loadGitResource(args)).rejects.toThrow('path traversal');
+		await expect(materializeResource(resource, '/anonymous-auth-fail')).rejects.toThrow(
+			'Authentication required or access denied'
+		);
+		await resource.cleanup?.();
+
+		const cloneEntries = (await readCommandLog(logPath)).filter((entry) => entry.cmd === 'clone');
+		expect(cloneEntries).toHaveLength(0);
+	});
+
+	it('cleans up anonymous temp checkouts if VFS import fails', async () => {
+		const logPath = path.join(testDir, 'git-log.jsonl');
+		const gitDeps = createGitTestDeps(logPath, {
+			importDirectoryIntoVirtualFs: async (args) => {
+				throw new Error(`forced import failure for ${args.sourcePath}`);
+			}
 		});
+
+		const resource = await loadGitResource(
+			{
+				type: 'git',
+				name: 'anonymous:https://example.com/repo-a.git',
+				url: 'https://example.com/repo-a.git',
+				branch: 'main',
+				repoSubPaths: [],
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true,
+				ephemeral: true
+			},
+			gitDeps
+		);
+
+		await expect(materializeResource(resource, '/anonymous-fail')).rejects.toThrow(
+			'forced import failure'
+		);
+
+		const cloneTargets = (await readCommandLog(logPath))
+			.filter((entry) => entry.cmd === 'clone')
+			.map((entry) => entry.repoPath as string);
+		expect(cloneTargets).toHaveLength(1);
+		expect(await pathExists(cloneTargets[0]!)).toBe(false);
+		await resource.cleanup?.();
 	});
 });

--- a/apps/server/src/resources/impls/git.ts
+++ b/apps/server/src/resources/impls/git.ts
@@ -2,34 +2,100 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { metricsInfo, withMetricsSpan } from '../../metrics/index.ts';
+import { importDirectoryIntoVirtualFs } from '../../vfs/virtual-fs.ts';
 import { CommonHints } from '../../errors.ts';
-import { ResourceError, resourceNameToKey } from '../helpers.ts';
+import { cleanupDirectory, directoryExists, pathExists } from '../fs-utils.ts';
+import { ResourceError, resourceNameToKey, shouldIgnoreCommonImportedPath } from '../helpers.ts';
+import { withClearAwareFilesystemLock } from '../lock.ts';
+import {
+	getClearLockPath,
+	getGitLockPath,
+	getGitMirrorRepoPath,
+	getTmpCacheRoot
+} from '../layout.ts';
 import { GitResourceSchema } from '../schema.ts';
-import type { BtcaFsResource, BtcaGitResourceArgs } from '../types.ts';
+import type { BtcaGitFsResource, BtcaGitResourceArgs } from '../types.ts';
 
 const ANONYMOUS_BRANCH_FALLBACKS = ['main', 'master', 'trunk', 'dev'];
-const ANONYMOUS_CLONE_DIR = '.tmp';
 
-const isBranchNotFoundError = (cause: unknown) => {
-	const message =
-		typeof cause === 'object' && cause instanceof Error ? cause.message : String(cause);
-	return (
-		/couldn't find remote ref/i.test(message) ||
-		/Remote branch .* not found/i.test(message) ||
-		/fatal: invalid refspec/i.test(message) ||
-		/error: pathspec .* did not match any/i.test(message) ||
-		/Branch ".*" not found in the repository/i.test(message) ||
-		/The specified branch was not found/i.test(message)
-	);
+type DisposableTempDir = {
+	readonly path: string;
+	readonly remove: () => Promise<void>;
 };
 
-const cleanupDirectory = async (pathToRemove: string) => {
-	try {
-		await fs.rm(pathToRemove, { recursive: true, force: true });
-	} catch {
-		return;
+type BunSpawnLike = typeof Bun.spawn;
+type ImportDirectoryIntoVirtualFsLike = typeof importDirectoryIntoVirtualFs;
+
+export type GitResourceDeps = {
+	readonly spawn: BunSpawnLike;
+	readonly importDirectoryIntoVirtualFs: ImportDirectoryIntoVirtualFsLike;
+};
+
+type ResolvedGitResourceArgs = {
+	readonly name: string;
+	readonly fsName: string;
+	readonly resourceKey: string;
+	readonly url: string;
+	readonly branch: string;
+	readonly repoSubPaths: readonly string[];
+	readonly resourcesDirectoryPath: string;
+	readonly specialAgentInstructions: string;
+	readonly quiet: boolean;
+	readonly ephemeral: boolean;
+	readonly namedLocalPath: string;
+	readonly clearLockPath: string;
+	readonly resourceLockPath: string;
+};
+
+type FsPromisesWithDisposable = typeof fs & {
+	readonly mkdtempDisposable?: (prefix: string) => Promise<{
+		readonly path: string;
+		readonly remove: () => Promise<void>;
+	}>;
+};
+
+const createDisposableTempDir = async (prefix: string): Promise<DisposableTempDir> => {
+	await fs.mkdir(path.dirname(prefix), { recursive: true });
+	const fsWithDisposable = fs as FsPromisesWithDisposable;
+	if (typeof fsWithDisposable.mkdtempDisposable === 'function') {
+		const disposableDir = await fsWithDisposable.mkdtempDisposable(prefix);
+		return {
+			path: disposableDir.path,
+			remove: async () => {
+				try {
+					await disposableDir.remove();
+				} catch {
+					await cleanupDirectory(disposableDir.path);
+				}
+			}
+		};
 	}
+
+	const localPath = await fs.mkdtemp(prefix);
+	return {
+		path: localPath,
+		remove: async () => {
+			await cleanupDirectory(localPath);
+		}
+	};
 };
+
+const removeDisposableTempDir = async (tempDir: DisposableTempDir | null) => {
+	if (!tempDir) return;
+	await tempDir.remove();
+};
+
+const defaultGitResourceDeps: GitResourceDeps = {
+	spawn: ((...spawnArgs: Parameters<typeof Bun.spawn>) =>
+		Bun.spawn(...spawnArgs)) as typeof Bun.spawn,
+	importDirectoryIntoVirtualFs
+};
+
+const resolveGitResourceDeps = (deps?: Partial<GitResourceDeps>): GitResourceDeps => ({
+	spawn: deps?.spawn ?? defaultGitResourceDeps.spawn,
+	importDirectoryIntoVirtualFs:
+		deps?.importDirectoryIntoVirtualFs ?? defaultGitResourceDeps.importDirectoryIntoVirtualFs
+});
 
 const validateGitUrl = (url: string): { success: true } | { success: false; error: string } => {
 	const result = GitResourceSchema.shape.url.safeParse(url);
@@ -51,13 +117,87 @@ const validateSearchPath = (
 	return { success: false, error: result.error.errors[0]?.message ?? 'Invalid search path' };
 };
 
-const directoryExists = async (path: string): Promise<boolean> => {
-	try {
-		const stat = await fs.stat(path);
-		return stat.isDirectory();
-	} catch {
-		return false;
+const resolveGitResourceArgs = (config: BtcaGitResourceArgs): ResolvedGitResourceArgs => {
+	const urlValidation = validateGitUrl(config.url);
+	if (!urlValidation.success) {
+		throw new ResourceError({
+			message: urlValidation.error,
+			hint: 'URLs must be valid HTTPS URLs. Example: https://github.com/user/repo',
+			cause: new Error('URL validation failed')
+		});
 	}
+
+	const branchValidation = validateBranch(config.branch);
+	if (!branchValidation.success) {
+		throw new ResourceError({
+			message: branchValidation.error,
+			hint: 'Branch names can only contain letters, numbers, hyphens, underscores, dots, and forward slashes.',
+			cause: new Error('Branch validation failed')
+		});
+	}
+
+	for (const repoSubPath of config.repoSubPaths) {
+		const pathValidation = validateSearchPath(repoSubPath);
+		if (!pathValidation.success) {
+			throw new ResourceError({
+				message: pathValidation.error,
+				hint: 'Search paths cannot contain ".." (path traversal) and must use only safe characters.',
+				cause: new Error('Path validation failed')
+			});
+		}
+	}
+
+	const resourceKey = config.localDirectoryKey ?? resourceNameToKey(config.name);
+	return {
+		name: config.name,
+		fsName: resourceNameToKey(config.name),
+		resourceKey,
+		url: config.url,
+		branch: config.branch,
+		repoSubPaths: [...config.repoSubPaths],
+		resourcesDirectoryPath: config.resourcesDirectoryPath,
+		specialAgentInstructions: config.specialAgentInstructions,
+		quiet: config.quiet,
+		ephemeral: config.ephemeral ?? false,
+		namedLocalPath: getGitMirrorRepoPath(config.resourcesDirectoryPath, resourceKey),
+		clearLockPath: getClearLockPath(config.resourcesDirectoryPath),
+		resourceLockPath: getGitLockPath(config.resourcesDirectoryPath, resourceKey)
+	};
+};
+
+const readGitStdout = async (
+	args: string[],
+	resourcePath: string,
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => {
+	try {
+		const proc = deps.spawn(['git', ...args], {
+			cwd: resourcePath,
+			stdout: 'pipe',
+			stderr: 'pipe'
+		});
+		const stdout = await new Response(proc.stdout).text();
+		const exitCode = await proc.exited;
+		if (exitCode !== 0) return null;
+		return stdout.trim();
+	} catch {
+		return null;
+	}
+};
+
+const getGitHeadHash = async (resourcePath: string, deps: Pick<GitResourceDeps, 'spawn'>) => {
+	const stdout = await readGitStdout(['rev-parse', 'HEAD'], resourcePath, deps);
+	return stdout && stdout.length > 0 ? stdout : undefined;
+};
+
+const isGitWorkingTree = async (resourcePath: string, deps: Pick<GitResourceDeps, 'spawn'>) => {
+	const stdout = await readGitStdout(['rev-parse', '--is-inside-work-tree'], resourcePath, deps);
+	return stdout === 'true';
+};
+
+const getGitOriginUrl = async (resourcePath: string, deps: Pick<GitResourceDeps, 'spawn'>) => {
+	const stdout = await readGitStdout(['remote', 'get-url', 'origin'], resourcePath, deps);
+	return stdout && stdout.length > 0 ? stdout : undefined;
 };
 
 /**
@@ -173,9 +313,10 @@ interface GitRunResult {
 const runGitChecked = async (
 	args: string[],
 	options: { cwd?: string; quiet: boolean },
-	buildError: (result: GitRunResult) => ResourceError
+	buildError: (result: GitRunResult) => ResourceError,
+	deps: Pick<GitResourceDeps, 'spawn'>
 ) => {
-	const runResult = await runGit(args, options);
+	const runResult = await runGit(args, options, deps);
 	if (runResult.exitCode !== 0) {
 		throw buildError(runResult);
 	}
@@ -184,10 +325,11 @@ const runGitChecked = async (
 
 const runGit = async (
 	args: string[],
-	options: { cwd?: string; quiet: boolean }
+	options: { cwd?: string; quiet: boolean },
+	deps: Pick<GitResourceDeps, 'spawn'>
 ): Promise<GitRunResult> => {
 	// Always capture stderr for error detection, but stdout can be ignored
-	const proc = Bun.spawn(['git', ...args], {
+	const proc = deps.spawn(['git', ...args], {
 		cwd: options.cwd,
 		stdout: options.quiet ? 'ignore' : 'inherit',
 		stderr: 'pipe'
@@ -224,40 +366,16 @@ const runGit = async (
 	return { exitCode, stderr };
 };
 
-const gitClone = async (args: {
-	repoUrl: string;
-	repoBranch: string;
-	repoSubPaths: readonly string[];
-	localAbsolutePath: string;
-	quiet: boolean;
-}) => {
-	const urlValidation = validateGitUrl(args.repoUrl);
-	if (!urlValidation.success) {
-		throw new ResourceError({
-			message: urlValidation.error,
-			hint: 'URLs must be valid HTTPS URLs. Example: https://github.com/user/repo',
-			cause: new Error('URL validation failed')
-		});
-	}
-	const branchValidation = validateBranch(args.repoBranch);
-	if (!branchValidation.success) {
-		throw new ResourceError({
-			message: branchValidation.error,
-			hint: 'Branch names can only contain letters, numbers, hyphens, underscores, dots, and forward slashes.',
-			cause: new Error('Branch validation failed')
-		});
-	}
-	for (const repoSubPath of args.repoSubPaths) {
-		const pathValidation = validateSearchPath(repoSubPath);
-		if (!pathValidation.success) {
-			throw new ResourceError({
-				message: pathValidation.error,
-				hint: 'Search paths cannot contain ".." (path traversal) and must use only safe characters.',
-				cause: new Error('Path validation failed')
-			});
-		}
-	}
-
+const gitClone = async (
+	args: {
+		repoUrl: string;
+		repoBranch: string;
+		repoSubPaths: readonly string[];
+		localAbsolutePath: string;
+		quiet: boolean;
+	},
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => {
 	const needsSparseCheckout = args.repoSubPaths.length > 0;
 	const cloneArgs = needsSparseCheckout
 		? [
@@ -272,22 +390,27 @@ const gitClone = async (args: {
 			]
 		: ['clone', '--depth', '1', '-b', args.repoBranch, args.repoUrl, args.localAbsolutePath];
 
-	await runGitChecked(cloneArgs, { quiet: args.quiet }, (cloneResult) => {
-		const errorType = detectGitErrorType(cloneResult.stderr);
-		const { message, hint } = getGitErrorDetails(errorType, {
-			operation: 'clone',
-			branch: args.repoBranch,
-			url: args.repoUrl
-		});
+	await runGitChecked(
+		cloneArgs,
+		{ quiet: args.quiet },
+		(cloneResult) => {
+			const errorType = detectGitErrorType(cloneResult.stderr);
+			const { message, hint } = getGitErrorDetails(errorType, {
+				operation: 'clone',
+				branch: args.repoBranch,
+				url: args.repoUrl
+			});
 
-		return new ResourceError({
-			message,
-			hint,
-			cause: new Error(
-				`git clone failed with exit code ${cloneResult.exitCode}: ${cloneResult.stderr}`
-			)
-		});
-	});
+			return new ResourceError({
+				message,
+				hint,
+				cause: new Error(
+					`git clone failed with exit code ${cloneResult.exitCode}: ${cloneResult.stderr}`
+				)
+			});
+		},
+		deps
+	);
 
 	if (needsSparseCheckout) {
 		await runGitChecked(
@@ -300,7 +423,8 @@ const gitClone = async (args: {
 					cause: new Error(
 						`git sparse-checkout failed with exit code ${sparseResult.exitCode}: ${sparseResult.stderr}`
 					)
-				})
+				}),
+			deps
 		);
 
 		await runGitChecked(
@@ -313,17 +437,111 @@ const gitClone = async (args: {
 					cause: new Error(
 						`git checkout failed with exit code ${checkout.exitCode}: ${checkout.stderr}`
 					)
-				})
+				}),
+			deps
 		);
 	}
 };
 
-const gitUpdate = async (args: {
-	localAbsolutePath: string;
-	branch: string;
-	repoSubPaths: readonly string[];
-	quiet: boolean;
-}) => {
+const probeRemoteBranch = async (
+	args: {
+		repoUrl: string;
+		repoBranch: string;
+	},
+	deps: Pick<GitResourceDeps, 'spawn'>
+): Promise<'exists' | 'missing'> => {
+	const probeResult = await runGit(
+		['ls-remote', '--exit-code', '--heads', args.repoUrl, `refs/heads/${args.repoBranch}`],
+		{ quiet: true },
+		deps
+	);
+
+	if (probeResult.exitCode === 0) return 'exists';
+	if (probeResult.exitCode === 2) return 'missing';
+
+	const errorType = detectGitErrorType(probeResult.stderr);
+	const { message, hint } = getGitErrorDetails(errorType, {
+		operation: 'probe remote branch',
+		branch: args.repoBranch,
+		url: args.repoUrl
+	});
+	throw new ResourceError({
+		message,
+		hint,
+		cause: new Error(
+			`git ls-remote failed with exit code ${probeResult.exitCode}: ${probeResult.stderr}`
+		)
+	});
+};
+
+const isSparseCheckoutEnabled = async (localAbsolutePath: string) =>
+	await pathExists(path.join(localAbsolutePath, '.git', 'info', 'sparse-checkout'));
+
+const applyMirrorCheckoutMode = async (
+	args: {
+		localAbsolutePath: string;
+		repoSubPaths: readonly string[];
+		quiet: boolean;
+	},
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => {
+	if (args.repoSubPaths.length > 0) {
+		await runGitChecked(
+			['sparse-checkout', 'set', ...args.repoSubPaths],
+			{ cwd: args.localAbsolutePath, quiet: args.quiet },
+			(sparseResult) =>
+				new ResourceError({
+					message: `Failed to set sparse-checkout path(s): "${args.repoSubPaths.join(', ')}"`,
+					hint: 'Verify the search paths exist in the repository. Check the repository structure to find the correct path.',
+					cause: new Error(
+						`git sparse-checkout failed with exit code ${sparseResult.exitCode}: ${sparseResult.stderr}`
+					)
+				}),
+			deps
+		);
+
+		await runGitChecked(
+			['checkout'],
+			{ cwd: args.localAbsolutePath, quiet: args.quiet },
+			(checkoutResult) =>
+				new ResourceError({
+					message: 'Failed to checkout repository',
+					hint: CommonHints.CLEAR_CACHE,
+					cause: new Error(
+						`git checkout failed with exit code ${checkoutResult.exitCode}: ${checkoutResult.stderr}`
+					)
+				}),
+			deps
+		);
+		return;
+	}
+
+	if (!(await isSparseCheckoutEnabled(args.localAbsolutePath))) return;
+
+	await runGitChecked(
+		['sparse-checkout', 'disable'],
+		{ cwd: args.localAbsolutePath, quiet: args.quiet },
+		(disableResult) =>
+			new ResourceError({
+				message: 'Failed to disable sparse-checkout for full repository mode',
+				hint: `${CommonHints.CLEAR_CACHE} This will re-clone the repository from scratch.`,
+				cause: new Error(
+					`git sparse-checkout disable failed with exit code ${disableResult.exitCode}: ${disableResult.stderr}`
+				)
+			}),
+		deps
+	);
+};
+
+const gitUpdate = async (
+	args: {
+		localAbsolutePath: string;
+		branch: string;
+		repoSubPaths: readonly string[];
+		quiet: boolean;
+	},
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => {
 	await runGitChecked(
 		['fetch', '--depth', '1', 'origin', args.branch],
 		{ cwd: args.localAbsolutePath, quiet: args.quiet },
@@ -341,7 +559,8 @@ const gitUpdate = async (args: {
 					`git fetch failed with exit code ${fetchResult.exitCode}: ${fetchResult.stderr}`
 				)
 			});
-		}
+		},
+		deps
 	);
 
 	await runGitChecked(
@@ -354,36 +573,11 @@ const gitUpdate = async (args: {
 				cause: new Error(
 					`git reset failed with exit code ${resetResult.exitCode}: ${resetResult.stderr}`
 				)
-			})
+			}),
+		deps
 	);
 
-	if (args.repoSubPaths.length > 0) {
-		await runGitChecked(
-			['sparse-checkout', 'set', ...args.repoSubPaths],
-			{ cwd: args.localAbsolutePath, quiet: args.quiet },
-			(sparseResult) =>
-				new ResourceError({
-					message: `Failed to set sparse-checkout path(s): "${args.repoSubPaths.join(', ')}"`,
-					hint: 'Verify the search paths exist in the repository. Check the repository structure to find the correct path.',
-					cause: new Error(
-						`git sparse-checkout failed with exit code ${sparseResult.exitCode}: ${sparseResult.stderr}`
-					)
-				})
-		);
-
-		await runGitChecked(
-			['checkout'],
-			{ cwd: args.localAbsolutePath, quiet: args.quiet },
-			(checkoutResult) =>
-				new ResourceError({
-					message: 'Failed to checkout repository',
-					hint: CommonHints.CLEAR_CACHE,
-					cause: new Error(
-						`git checkout failed with exit code ${checkoutResult.exitCode}: ${checkoutResult.stderr}`
-					)
-				})
-		);
-	}
+	await applyMirrorCheckoutMode(args, deps);
 };
 
 /**
@@ -411,7 +605,7 @@ const getSearchPathHint = (searchPath: string, repoPath: string): string => {
 	return `Verify the path exists in the repository. To see available directories, run:\n  ls ${repoPath}`;
 };
 
-const ensureSearchPathsExist = async (
+const ensureResolvedRepoSubPathsExist = async (
 	localPath: string,
 	repoSubPaths: readonly string[],
 	resourceName: string
@@ -430,13 +624,8 @@ const ensureSearchPathsExist = async (
 	}
 };
 
-const ensureGitResource = async (config: BtcaGitResourceArgs): Promise<string> => {
-	const resourceKey = config.localDirectoryKey ?? resourceNameToKey(config.name);
-	const basePath = config.ephemeral
-		? path.join(config.resourcesDirectoryPath, ANONYMOUS_CLONE_DIR)
-		: config.resourcesDirectoryPath;
-	const localPath = path.join(basePath, resourceKey);
-
+const ensureMirrorDirectories = async (config: ResolvedGitResourceArgs) => {
+	const basePath = path.dirname(config.namedLocalPath);
 	try {
 		await fs.mkdir(basePath, { recursive: true });
 	} catch (cause) {
@@ -446,104 +635,257 @@ const ensureGitResource = async (config: BtcaGitResourceArgs): Promise<string> =
 			cause
 		});
 	}
+};
 
-	if (config.ephemeral) {
-		await cleanupDirectory(localPath);
-	}
+const mirrorRepoExists = async (config: ResolvedGitResourceArgs) =>
+	await directoryExists(config.namedLocalPath);
 
+const readMirrorOriginUrl = async (
+	config: ResolvedGitResourceArgs,
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => await getGitOriginUrl(config.namedLocalPath, deps);
+
+const cloneNamedMirror = async (
+	config: ResolvedGitResourceArgs,
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => {
+	await gitClone(
+		{
+			repoUrl: config.url,
+			repoBranch: config.branch,
+			repoSubPaths: config.repoSubPaths,
+			localAbsolutePath: config.namedLocalPath,
+			quiet: config.quiet
+		},
+		deps
+	);
+};
+
+const updateNamedMirror = async (
+	config: ResolvedGitResourceArgs,
+	deps: Pick<GitResourceDeps, 'spawn'>
+) => {
+	await gitUpdate(
+		{
+			localAbsolutePath: config.namedLocalPath,
+			branch: config.branch,
+			repoSubPaths: config.repoSubPaths,
+			quiet: config.quiet
+		},
+		deps
+	);
+};
+
+const readHeadCommit = async (localPath: string, deps: Pick<GitResourceDeps, 'spawn'>) =>
+	await getGitHeadHash(localPath, deps);
+
+const reconcileNamedMirror = async (
+	config: ResolvedGitResourceArgs,
+	deps: Pick<GitResourceDeps, 'spawn'>
+): Promise<{ localPath: string }> => {
+	await ensureMirrorDirectories(config);
 	return withMetricsSpan(
 		'resource.git.ensure',
 		async () => {
-			const exists = await directoryExists(localPath);
+			if (await mirrorRepoExists(config)) {
+				const validGitWorkingTree = await isGitWorkingTree(config.namedLocalPath, deps);
+				if (!validGitWorkingTree) {
+					await cleanupDirectory(config.namedLocalPath);
+				} else {
+					const originUrl = await readMirrorOriginUrl(config, deps);
+					if (originUrl !== config.url) {
+						await cleanupDirectory(config.namedLocalPath);
+					}
+				}
+			}
 
-			if (exists && !config.ephemeral) {
+			if (await mirrorRepoExists(config)) {
 				metricsInfo('resource.git.update', {
 					name: config.name,
 					branch: config.branch,
 					repoSubPaths: config.repoSubPaths
 				});
-				await gitUpdate({
-					localAbsolutePath: localPath,
-					branch: config.branch,
-					repoSubPaths: config.repoSubPaths,
-					quiet: config.quiet
-				});
+				await updateNamedMirror(config, deps);
 				if (config.repoSubPaths.length > 0) {
-					await ensureSearchPathsExist(localPath, config.repoSubPaths, config.name);
+					await ensureResolvedRepoSubPathsExist(
+						config.namedLocalPath,
+						config.repoSubPaths,
+						config.name
+					);
 				}
-				return localPath;
+				return { localPath: config.namedLocalPath };
 			}
 
 			metricsInfo('resource.git.clone', {
 				name: config.name,
-				branch: config.ephemeral ? 'fallback' : config.branch,
+				branch: config.branch,
 				repoSubPaths: config.repoSubPaths
 			});
 
-			if (config.ephemeral) {
-				let lastBranchError: unknown;
-				for (const branch of ANONYMOUS_BRANCH_FALLBACKS) {
-					try {
-						await gitClone({
-							repoUrl: config.url,
-							repoBranch: branch,
-							repoSubPaths: config.repoSubPaths,
-							localAbsolutePath: localPath,
-							quiet: config.quiet
-						});
-						if (config.repoSubPaths.length > 0) {
-							await ensureSearchPathsExist(localPath, config.repoSubPaths, config.name);
-						}
-						return localPath;
-					} catch (error) {
-						lastBranchError = error;
-						await cleanupDirectory(localPath);
-						if (!isBranchNotFoundError(error)) throw error;
-					}
-				}
-
-				throw new ResourceError({
-					message: `Could not find this repository on a common branch. Tried ${ANONYMOUS_BRANCH_FALLBACKS.join(
-						', '
-					)}.`,
-					hint: 'If the repo uses a different branch, add it as a named resource and use that name. See https://docs.btca.dev/guides/configuration.',
-					cause: lastBranchError
-				});
-			}
-
-			await gitClone({
-				repoUrl: config.url,
-				repoBranch: config.branch,
-				repoSubPaths: config.repoSubPaths,
-				localAbsolutePath: localPath,
-				quiet: config.quiet
-			});
+			await cloneNamedMirror(config, deps);
 			if (config.repoSubPaths.length > 0) {
-				await ensureSearchPathsExist(localPath, config.repoSubPaths, config.name);
+				await ensureResolvedRepoSubPathsExist(
+					config.namedLocalPath,
+					config.repoSubPaths,
+					config.name
+				);
 			}
 
-			return localPath;
+			return { localPath: config.namedLocalPath };
 		},
 		{ resource: config.name }
 	);
 };
 
-export const loadGitResource = async (config: BtcaGitResourceArgs): Promise<BtcaFsResource> => {
-	const localPath = await ensureGitResource(config);
-	const cleanup = config.ephemeral
+const materializeAnonymousGitResource = async (
+	config: ResolvedGitResourceArgs,
+	deps: Pick<GitResourceDeps, 'spawn'>
+): Promise<{ localPath: string; branch: string; tempDir: DisposableTempDir }> => {
+	const tempDir = await createDisposableTempDir(
+		path.join(
+			getTmpCacheRoot(config.resourcesDirectoryPath),
+			`btca-anon-git-${config.resourceKey}-`
+		)
+	);
+	let lastBranchError: unknown;
+
+	for (const branch of ANONYMOUS_BRANCH_FALLBACKS) {
+		const branchStatus = await probeRemoteBranch(
+			{
+				repoUrl: config.url,
+				repoBranch: branch
+			},
+			deps
+		);
+		if (branchStatus === 'missing') continue;
+
+		try {
+			await fs.mkdir(tempDir.path, { recursive: true });
+			await gitClone(
+				{
+					repoUrl: config.url,
+					repoBranch: branch,
+					repoSubPaths: config.repoSubPaths,
+					localAbsolutePath: tempDir.path,
+					quiet: config.quiet
+				},
+				deps
+			);
+			if (config.repoSubPaths.length > 0) {
+				await ensureResolvedRepoSubPathsExist(tempDir.path, config.repoSubPaths, config.name);
+			}
+			return { localPath: tempDir.path, branch, tempDir };
+		} catch (error) {
+			lastBranchError = error;
+			await cleanupDirectory(tempDir.path);
+			throw error;
+		}
+	}
+
+	await removeDisposableTempDir(tempDir);
+
+	throw new ResourceError({
+		message: `Could not find this repository on a common branch. Tried ${ANONYMOUS_BRANCH_FALLBACKS.join(
+			', '
+		)}.`,
+		hint: 'If the repo uses a different branch, add it as a named resource and use that name. See https://docs.btca.dev/guides/configuration.',
+		cause: lastBranchError
+	});
+};
+
+export const loadGitResource = async (
+	config: BtcaGitResourceArgs,
+	deps?: Partial<GitResourceDeps>
+): Promise<BtcaGitFsResource> => {
+	const resolved = resolveGitResourceArgs(config);
+	const gitDeps = resolveGitResourceDeps(deps);
+
+	let anonymousTempDir: DisposableTempDir | null = null;
+	let latestAnonymousMaterializationId = 0;
+	const cleanup = resolved.ephemeral
 		? async () => {
-				await cleanupDirectory(localPath);
+				latestAnonymousMaterializationId += 1;
+				const currentTempDir = anonymousTempDir;
+				anonymousTempDir = null;
+				await removeDisposableTempDir(currentTempDir);
 			}
 		: undefined;
 
 	return {
 		_tag: 'fs-based',
-		name: config.name,
-		fsName: resourceNameToKey(config.name),
+		name: resolved.name,
+		fsName: resolved.fsName,
 		type: 'git',
-		repoSubPaths: config.repoSubPaths,
-		specialAgentInstructions: config.specialAgentInstructions,
-		getAbsoluteDirectoryPath: async () => localPath,
+		repoSubPaths: resolved.repoSubPaths,
+		specialAgentInstructions: resolved.specialAgentInstructions,
+		materializeIntoVirtualFs: async ({ destinationPath, vfsId }) => {
+			const materializeAndImport = async () => {
+				const materializationId = resolved.ephemeral ? latestAnonymousMaterializationId + 1 : 0;
+				if (resolved.ephemeral) latestAnonymousMaterializationId = materializationId;
+
+				if (resolved.ephemeral) {
+					const materialized = await materializeAnonymousGitResource(resolved, gitDeps);
+					const commit = await readHeadCommit(materialized.localPath, gitDeps);
+					try {
+						await gitDeps.importDirectoryIntoVirtualFs({
+							sourcePath: materialized.localPath,
+							destinationPath,
+							vfsId,
+							ignore: shouldIgnoreCommonImportedPath
+						});
+
+						if (materializationId === latestAnonymousMaterializationId) {
+							const previousTempDir = anonymousTempDir;
+							anonymousTempDir = materialized.tempDir;
+							await removeDisposableTempDir(previousTempDir);
+						} else {
+							await removeDisposableTempDir(materialized.tempDir);
+						}
+
+						return {
+							metadata: {
+								url: resolved.url,
+								branch: materialized.branch,
+								...(commit ? { commit } : {})
+							}
+						};
+					} catch (cause) {
+						await removeDisposableTempDir(materialized.tempDir);
+						throw cause;
+					}
+				}
+
+				const materialized = await reconcileNamedMirror(resolved, gitDeps);
+				const commit = await readHeadCommit(materialized.localPath, gitDeps);
+
+				await gitDeps.importDirectoryIntoVirtualFs({
+					sourcePath: materialized.localPath,
+					destinationPath,
+					vfsId,
+					ignore: shouldIgnoreCommonImportedPath
+				});
+
+				return {
+					metadata: {
+						url: resolved.url,
+						branch: resolved.branch,
+						...(commit ? { commit } : {})
+					}
+				};
+			};
+
+			return withClearAwareFilesystemLock(
+				{
+					clearLockPath: resolved.clearLockPath,
+					clearLockWaitLabel: `wait-clear-before-git.${resolved.resourceKey}`,
+					clearLockInspectLabel: `inspect-clear-before-git.${resolved.resourceKey}`,
+					resourceLockPath: resolved.resourceLockPath,
+					resourceLockLabel: `git.${resolved.resourceKey}`,
+					quiet: resolved.quiet
+				},
+				materializeAndImport
+			);
+		},
 		...(cleanup ? { cleanup } : {})
 	};
 };

--- a/apps/server/src/resources/impls/local.ts
+++ b/apps/server/src/resources/impls/local.ts
@@ -1,0 +1,62 @@
+import { importDirectoryIntoVirtualFs, importPathsIntoVirtualFs } from '../../vfs/virtual-fs.ts';
+import { type BtcaLocalFsResource, type BtcaLocalResourceArgs } from '../types.ts';
+import { ResourceError, resourceNameToKey, shouldIgnoreLocalImportedPath } from '../helpers.ts';
+
+const listGitVisiblePaths = async (resourcePath: string) => {
+	try {
+		const proc = Bun.spawn(
+			['git', 'ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+			{
+				cwd: resourcePath,
+				stdout: 'pipe',
+				stderr: 'ignore'
+			}
+		);
+		const stdout = await new Response(proc.stdout).text();
+		const exitCode = await proc.exited;
+		if (exitCode !== 0) return null;
+		return stdout
+			.split('\0')
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0);
+	} catch {
+		return null;
+	}
+};
+
+export const loadLocalResource = (args: BtcaLocalResourceArgs): BtcaLocalFsResource => ({
+	_tag: 'fs-based',
+	name: args.name,
+	fsName: resourceNameToKey(args.name),
+	type: 'local',
+	repoSubPaths: [],
+	specialAgentInstructions: args.specialAgentInstructions,
+	materializeIntoVirtualFs: async ({ destinationPath, vfsId }) => {
+		try {
+			const gitVisiblePaths = await listGitVisiblePaths(args.path);
+			if (gitVisiblePaths) {
+				await importPathsIntoVirtualFs({
+					sourcePath: args.path,
+					destinationPath,
+					relativePaths: gitVisiblePaths,
+					vfsId
+				});
+			} else {
+				await importDirectoryIntoVirtualFs({
+					sourcePath: args.path,
+					destinationPath,
+					vfsId,
+					ignore: shouldIgnoreLocalImportedPath
+				});
+			}
+		} catch (cause) {
+			throw new ResourceError({
+				message: `Failed to materialize local resource "${args.name}"`,
+				hint: 'Check that the local path exists and is readable.',
+				cause
+			});
+		}
+
+		return { metadata: {} };
+	}
+});

--- a/apps/server/src/resources/impls/npm.process.test.ts
+++ b/apps/server/src/resources/impls/npm.process.test.ts
@@ -1,0 +1,602 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createAnonymousDirectoryKey, createResourcesService } from '../service.ts';
+import { setFilesystemLockTestHookForTests, type FilesystemLockTestEvent } from '../lock.ts';
+import { getNpmLockPath } from '../layout.ts';
+import type { ResourceDefinition } from '../schema.ts';
+import { createConfigServiceMock, createStaleLockDirectory } from '../test-support.ts';
+import { logQueueMetrics, readStream, waitFor } from './test-fixtures/process-support.ts';
+
+const workerPath = path.join(import.meta.dir, 'test-fixtures', 'npm-materialize-worker.ts');
+
+type WorkerAction =
+	| {
+			readonly type: 'materialize';
+			readonly reference: string;
+			readonly destinationPath?: string;
+	  }
+	| {
+			readonly type: 'cleanup';
+			readonly reference: string;
+	  }
+	| {
+			readonly type: 'clear';
+	  };
+
+type WorkerMockConfig = {
+	readonly packageName: string;
+	readonly resolvedVersion: string;
+	readonly pageHtml?: string;
+	readonly holdInstallUntilContinue?: boolean;
+	readonly exitCode?: number;
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly exitBeforeResult?: boolean;
+};
+
+type WorkerConfig = {
+	readonly resourcesDirectory: string;
+	readonly resources: readonly ResourceDefinition[];
+	readonly action: WorkerAction;
+	readonly mock: WorkerMockConfig;
+};
+
+type ParentToChildMessage = {
+	readonly type: 'continue-install';
+};
+
+type ChildToParentMessage =
+	| {
+			readonly type: 'install-started';
+			readonly packageSpec: string;
+			readonly cwd?: string;
+	  }
+	| {
+			readonly type: 'lock-event';
+			readonly event: FilesystemLockTestEvent;
+	  }
+	| {
+			readonly type: 'result';
+			readonly result: unknown;
+	  }
+	| {
+			readonly type: 'error';
+			readonly message: string;
+	  };
+
+type SpawnedWorker = {
+	readonly process: ReturnType<typeof Bun.spawn>;
+	readonly exitPromise: Promise<number>;
+	readonly stdoutPromise: Promise<string>;
+	readonly stderrPromise: Promise<string>;
+	readonly messages: ReturnType<typeof createMessageBuffer>;
+	readonly send: (message: ParentToChildMessage) => void;
+	readonly hasExited: () => boolean;
+};
+
+const pathExists = async (targetPath: string) => {
+	try {
+		await fs.stat(targetPath);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const createMessageBuffer = () => {
+	const pendingMessages: ChildToParentMessage[] = [];
+	const waiters = new Set<{
+		readonly predicate: (message: ChildToParentMessage) => boolean;
+		readonly resolve: (message: ChildToParentMessage) => void;
+		readonly reject: (cause: Error) => void;
+		readonly timer: ReturnType<typeof setTimeout>;
+	}>();
+
+	return {
+		push(message: ChildToParentMessage) {
+			for (const waiter of waiters) {
+				if (!waiter.predicate(message)) continue;
+				clearTimeout(waiter.timer);
+				waiters.delete(waiter);
+				waiter.resolve(message);
+				return;
+			}
+			pendingMessages.push(message);
+		},
+		waitFor(
+			predicate: (message: ChildToParentMessage) => boolean,
+			timeoutMs = 4_000
+		): Promise<ChildToParentMessage> {
+			const existing = pendingMessages.find(predicate);
+			if (existing) {
+				pendingMessages.splice(pendingMessages.indexOf(existing), 1);
+				return Promise.resolve(existing);
+			}
+
+			return new Promise((resolve, reject) => {
+				const waiter = {
+					predicate,
+					resolve,
+					reject,
+					timer: setTimeout(() => {
+						waiters.delete(waiter);
+						reject(new Error('Timed out waiting for worker IPC message'));
+					}, timeoutMs)
+				};
+				waiters.add(waiter);
+			});
+		}
+	};
+};
+
+const spawnWorker = async (config: WorkerConfig): Promise<SpawnedWorker> => {
+	const workerDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-npm-worker-'));
+	const configPath = path.join(workerDir, 'worker-config.json');
+	await Bun.write(configPath, JSON.stringify(config, null, 2));
+
+	const messages = createMessageBuffer();
+	let exitCode: number | null = null;
+	const childProcess = Bun.spawn([process.execPath, workerPath, configPath], {
+		stdout: 'pipe',
+		stderr: 'pipe',
+		serialization: 'json',
+		ipc(message) {
+			if (!message || typeof message !== 'object') return;
+			const type = Reflect.get(message, 'type');
+			if (
+				type === 'install-started' ||
+				type === 'lock-event' ||
+				type === 'result' ||
+				type === 'error'
+			) {
+				messages.push(message as ChildToParentMessage);
+			}
+		}
+	});
+
+	const stdoutPromise = readStream(childProcess.stdout);
+	const stderrPromise = readStream(childProcess.stderr);
+	const exitPromise = childProcess.exited.then(async (code) => {
+		exitCode = code;
+		await fs.rm(workerDir, { recursive: true, force: true });
+		return code;
+	});
+
+	return {
+		process: childProcess,
+		exitPromise,
+		stdoutPromise,
+		stderrPromise,
+		messages,
+		send(message) {
+			childProcess.send(message);
+		},
+		hasExited: () => exitCode !== null
+	};
+};
+
+const waitForInstallStarted = async (worker: SpawnedWorker) => {
+	const message = await Promise.race([
+		worker.messages.waitFor((candidate) => candidate.type === 'install-started'),
+		worker.exitPromise.then(() => 'exited' as const)
+	]);
+
+	if (message === 'exited') {
+		const [exitCode, stdout, stderr] = await Promise.all([
+			worker.exitPromise,
+			worker.stdoutPromise,
+			worker.stderrPromise
+		]);
+		throw new Error(
+			`Worker exited ${exitCode} before sending install-started.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+		);
+	}
+
+	if (message.type !== 'install-started') {
+		throw new Error(`Expected install-started IPC message, received ${message.type}`);
+	}
+
+	return message;
+};
+
+const waitForWorkerLockEvent = async (
+	worker: SpawnedWorker,
+	predicate: (event: FilesystemLockTestEvent) => boolean,
+	timeoutMs = 4_000
+) => {
+	const message = await worker.messages.waitFor(
+		(candidate) => candidate.type === 'lock-event' && predicate(candidate.event),
+		timeoutMs
+	);
+	if (message.type !== 'lock-event') {
+		throw new Error(`Expected lock-event IPC message, received ${message.type}`);
+	}
+	return message.event;
+};
+
+const waitForWorker = async <T>(worker: SpawnedWorker): Promise<T> => {
+	const terminalMessage = await Promise.race([
+		worker.messages.waitFor(
+			(candidate) => candidate.type === 'result' || candidate.type === 'error',
+			5_000
+		),
+		worker.exitPromise.then(() => 'exited' as const)
+	]);
+
+	if (terminalMessage === 'exited') {
+		const [exitCode, stdout, stderr] = await Promise.all([
+			worker.exitPromise,
+			worker.stdoutPromise,
+			worker.stderrPromise
+		]);
+		throw new Error(
+			`Worker exited ${exitCode} before sending a terminal IPC message.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+		);
+	}
+
+	const [exitCode, stdout, stderr] = await Promise.all([
+		worker.exitPromise,
+		worker.stdoutPromise,
+		worker.stderrPromise
+	]);
+	if (terminalMessage.type === 'error') {
+		throw new Error(
+			`Worker reported an error: ${terminalMessage.message}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+		);
+	}
+	if (terminalMessage.type !== 'result') {
+		throw new Error(`Expected result IPC message, received ${terminalMessage.type}`);
+	}
+
+	if (exitCode !== 0) {
+		throw new Error(
+			`Worker exited ${exitCode} after sending result.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+		);
+	}
+
+	return terminalMessage.result as T;
+};
+
+describe('npm process locking', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-npm-process-'));
+	});
+
+	afterEach(async () => {
+		setFilesystemLockTestHookForTests();
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it('measures same-resource queueing for concurrent named npm materialization', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const resourceName = 'react-docs';
+		const packageName = 'react';
+		const resourceLockPath = getNpmLockPath(resourcesDirectory, resourceName);
+		const resources = [{ type: 'npm', name: resourceName, package: packageName }] as const;
+
+		const startedAt = performance.now();
+		const firstWorker = await spawnWorker({
+			resourcesDirectory,
+			resources,
+			action: { type: 'materialize', reference: resourceName },
+			mock: {
+				packageName,
+				resolvedVersion: '19.0.0',
+				holdInstallUntilContinue: true
+			}
+		});
+
+		await waitForInstallStarted(firstWorker);
+
+		const queuedWorkerStartedAt = performance.now();
+		const secondWorker = await spawnWorker({
+			resourcesDirectory,
+			resources,
+			action: { type: 'materialize', reference: resourceName },
+			mock: {
+				packageName,
+				resolvedVersion: '19.0.0',
+				holdInstallUntilContinue: true
+			}
+		});
+
+		await waitForWorkerLockEvent(
+			secondWorker,
+			(event) => event.phase === 'waiting-on-live-lock' && event.lockPath === resourceLockPath
+		);
+
+		firstWorker.send({ type: 'continue-install' });
+		const firstResultPromise = waitForWorker<{ metadata: { package?: string } }>(firstWorker);
+		const secondInstallStarted = await waitForInstallStarted(secondWorker);
+		const queuedWorkerWaitMs = performance.now() - queuedWorkerStartedAt;
+
+		expect(secondInstallStarted.type).toBe('install-started');
+
+		secondWorker.send({ type: 'continue-install' });
+		const [firstResult, secondResult] = await Promise.all([
+			firstResultPromise,
+			waitForWorker<{ metadata: { package?: string } }>(secondWorker)
+		]);
+
+		logQueueMetrics('npm.named.same-resource', {
+			totalElapsedMs: performance.now() - startedAt,
+			queuedWorkerWaitMs
+		});
+
+		expect(firstResult.metadata.package).toBe(packageName);
+		expect(secondResult.metadata.package).toBe(packageName);
+	});
+
+	it('clear waits for an in-flight named npm materialization even before metadata exists', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const resourceName = 'react-docs';
+		const packageName = 'react';
+		const cachePath = path.join(resourcesDirectory, resourceName);
+		const resourceLockPath = getNpmLockPath(resourcesDirectory, resourceName);
+		let clearBlocked = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (
+				event.phase === 'waiting-on-live-lock' &&
+				event.lockPath === resourceLockPath &&
+				event.label === `clear.npm.${resourceName}`
+			) {
+				clearBlocked = true;
+			}
+		});
+
+		const worker = await spawnWorker({
+			resourcesDirectory,
+			resources: [{ type: 'npm', name: resourceName, package: packageName }],
+			action: { type: 'materialize', reference: resourceName },
+			mock: {
+				packageName,
+				resolvedVersion: '19.0.0',
+				holdInstallUntilContinue: true
+			}
+		});
+
+		await waitForInstallStarted(worker);
+		await waitFor(() => pathExists(cachePath));
+		expect(await pathExists(path.join(cachePath, '.btca-npm-meta.json'))).toBe(false);
+
+		const service = createResourcesService(
+			createConfigServiceMock({
+				resourcesDirectory,
+				resources: [{ type: 'npm', name: resourceName, package: packageName }]
+			})
+		);
+
+		const clearPromise = service.clearCachesPromise();
+		await waitFor(() => clearBlocked);
+
+		worker.send({ type: 'continue-install' });
+		const [workerResult, clearResult] = await Promise.all([
+			waitForWorker<{ metadata: { package?: string } }>(worker),
+			clearPromise
+		]);
+
+		expect(workerResult.metadata.package).toBe(packageName);
+		expect(clearResult.cleared).toBeGreaterThanOrEqual(1);
+		expect(await pathExists(cachePath)).toBe(false);
+	});
+
+	it('clear drains extra anonymous npm locks and removes tmp caches', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const reference = 'react';
+		const resourceName = 'anonymous:npm:react';
+		const anonymousKey = createAnonymousDirectoryKey(reference);
+		const tmpCachePath = path.join(resourcesDirectory, '.tmp', anonymousKey);
+		const resourceLockPath = getNpmLockPath(resourcesDirectory, anonymousKey);
+		let clearBlocked = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (
+				event.phase === 'waiting-on-live-lock' &&
+				event.lockPath === resourceLockPath &&
+				event.label === `clear.npm.${anonymousKey}`
+			) {
+				clearBlocked = true;
+			}
+		});
+
+		const worker = await spawnWorker({
+			resourcesDirectory,
+			resources: [{ type: 'npm', name: resourceName, package: reference }],
+			action: { type: 'materialize', reference: resourceName },
+			mock: {
+				packageName: reference,
+				resolvedVersion: '19.0.0',
+				holdInstallUntilContinue: true
+			}
+		});
+
+		await waitForInstallStarted(worker);
+		await waitFor(() => pathExists(tmpCachePath));
+
+		const service = createResourcesService(
+			createConfigServiceMock({
+				resourcesDirectory,
+				resources: []
+			})
+		);
+
+		const clearPromise = service.clearCachesPromise();
+		await waitFor(() => clearBlocked);
+
+		worker.send({ type: 'continue-install' });
+		const [workerResult, clearResult] = await Promise.all([
+			waitForWorker<{ metadata: { package?: string } }>(worker),
+			clearPromise
+		]);
+
+		expect(workerResult.metadata.package).toBe(reference);
+		expect(clearResult.cleared).toBeGreaterThanOrEqual(1);
+		expect(await pathExists(tmpCachePath)).toBe(false);
+	});
+
+	it('overlapping anonymous npm cleanup waits for live materialization before removing the tmp cache', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const reference = 'react';
+		const resourceName = 'anonymous:npm:react';
+		const anonymousKey = createAnonymousDirectoryKey(reference);
+		const tmpCachePath = path.join(resourcesDirectory, '.tmp', anonymousKey);
+		const resourceLockPath = getNpmLockPath(resourcesDirectory, anonymousKey);
+		const resources = [{ type: 'npm', name: resourceName, package: reference }] as const;
+
+		const materializeWorker = await spawnWorker({
+			resourcesDirectory,
+			resources,
+			action: { type: 'materialize', reference: resourceName },
+			mock: {
+				packageName: reference,
+				resolvedVersion: '19.0.0',
+				holdInstallUntilContinue: true
+			}
+		});
+
+		await waitForInstallStarted(materializeWorker);
+		await waitFor(() => pathExists(tmpCachePath));
+
+		const cleanupWorker = await spawnWorker({
+			resourcesDirectory,
+			resources,
+			action: { type: 'cleanup', reference: resourceName },
+			mock: {
+				packageName: reference,
+				resolvedVersion: '19.0.0'
+			}
+		});
+
+		const cleanupPromise = waitForWorker<{ cleaned: boolean; name: string }>(cleanupWorker);
+		await waitForWorkerLockEvent(
+			cleanupWorker,
+			(event) => event.phase === 'waiting-on-live-lock' && event.lockPath === resourceLockPath
+		);
+		expect(await pathExists(tmpCachePath)).toBe(true);
+
+		materializeWorker.send({ type: 'continue-install' });
+		const [materializeResult, cleanupResult] = await Promise.all([
+			waitForWorker<{ metadata: { package?: string } }>(materializeWorker),
+			cleanupPromise
+		]);
+
+		expect(materializeResult.metadata.package).toBe(reference);
+		expect(cleanupResult.cleaned).toBe(true);
+		expect(cleanupResult.name).toBe(resourceName);
+		expect(await pathExists(tmpCachePath)).toBe(false);
+	});
+
+	it('clear keeps npm lock ordering even when config now reuses the key for git', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const resourceName = 'shared-key';
+		const packageName = 'react';
+		const cachePath = path.join(resourcesDirectory, resourceName);
+		const metaPath = path.join(cachePath, '.btca-npm-meta.json');
+		const resourceLockPath = getNpmLockPath(resourcesDirectory, resourceName);
+		let clearBlocked = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (
+				event.phase === 'waiting-on-live-lock' &&
+				event.lockPath === resourceLockPath &&
+				event.label === `clear.npm.${resourceName}`
+			) {
+				clearBlocked = true;
+			}
+		});
+
+		const worker = await spawnWorker({
+			resourcesDirectory,
+			resources: [{ type: 'npm', name: resourceName, package: packageName }],
+			action: { type: 'materialize', reference: resourceName },
+			mock: {
+				packageName,
+				resolvedVersion: '19.0.0',
+				holdInstallUntilContinue: true
+			}
+		});
+
+		await waitForInstallStarted(worker);
+		await waitFor(() => pathExists(cachePath));
+		await Bun.write(
+			metaPath,
+			JSON.stringify(
+				{
+					packageName,
+					resolvedVersion: '19.0.0',
+					packageUrl: 'https://www.npmjs.com/package/react',
+					pageUrl: 'https://www.npmjs.com/package/react/v/19.0.0',
+					fetchedAt: new Date().toISOString()
+				},
+				null,
+				2
+			)
+		);
+
+		const service = createResourcesService(
+			createConfigServiceMock({
+				resourcesDirectory,
+				resources: [
+					{
+						type: 'git',
+						name: resourceName,
+						url: 'https://example.com/repo.git',
+						branch: 'main'
+					}
+				]
+			})
+		);
+
+		const clearPromise = service.clearCachesPromise();
+		await waitFor(() => clearBlocked);
+
+		worker.send({ type: 'continue-install' });
+		const [workerResult, clearResult] = await Promise.all([
+			waitForWorker<{ metadata: { package?: string } }>(worker),
+			clearPromise
+		]);
+
+		expect(workerResult.metadata.package).toBe(packageName);
+		expect(clearResult.cleared).toBeGreaterThanOrEqual(1);
+		expect(await pathExists(cachePath)).toBe(false);
+	});
+
+	it('named npm materialization recovers after a stale clear.lock instead of hanging', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		await createStaleLockDirectory(path.join(resourcesDirectory, '.resource-locks', 'clear.lock'));
+
+		const worker = await spawnWorker({
+			resourcesDirectory,
+			resources: [{ type: 'npm', name: 'react-docs', package: 'react' }],
+			action: { type: 'materialize', reference: 'react-docs' },
+			mock: {
+				packageName: 'react',
+				resolvedVersion: '19.0.0'
+			}
+		});
+
+		const result = await waitForWorker<{ metadata: { package?: string } }>(worker);
+		expect(result.metadata.package).toBe('react');
+	});
+
+	it('surfaces stdout and stderr if the worker exits before sending a result', async () => {
+		const resourcesDirectory = path.join(tempDir, 'resources');
+		const worker = await spawnWorker({
+			resourcesDirectory,
+			resources: [{ type: 'npm', name: 'react-docs', package: 'react' }],
+			action: { type: 'materialize', reference: 'react-docs' },
+			mock: {
+				packageName: 'react',
+				resolvedVersion: '19.0.0',
+				stdout: 'worker stdout',
+				stderr: 'worker stderr',
+				exitBeforeResult: true
+			}
+		});
+
+		await expect(waitForWorker(worker)).rejects.toThrow(/worker stdout[\s\S]*worker stderr/);
+	});
+});

--- a/apps/server/src/resources/impls/npm.test.ts
+++ b/apps/server/src/resources/impls/npm.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
 import { promises as fs } from 'node:fs';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
@@ -141,6 +141,59 @@ describe('NPM Resource', () => {
 
 			const packagePage = await Bun.file(path.join(resourcePath, 'npm-package-page.html')).text();
 			expect(packagePage).toContain('<title>react</title>');
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
+	});
+
+	it('uses the resolved installed version for tag-based npm metadata', async () => {
+		const npmDeps = createNpmTestDeps(createInstallSpawnMock());
+		globalThis.fetch = (async (input) => {
+			const url = String(input);
+			if (url.startsWith('https://registry.npmjs.org/react')) {
+				return new Response(
+					JSON.stringify({
+						'dist-tags': { latest: '19.1.0' },
+						versions: {
+							'19.1.0': {
+								name: 'react',
+								version: '19.1.0',
+								description: 'React',
+								readme: '# React\n\nDocs'
+							}
+						}
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } }
+				);
+			}
+			if (url.startsWith('https://www.npmjs.com/package/react/v/19.1.0')) {
+				return new Response('<html><title>react</title></html>', { status: 200 });
+			}
+			return new Response('not found', { status: 404 });
+		}) as typeof fetch;
+
+		const resource = await loadNpmResource(
+			{
+				type: 'npm',
+				name: 'react-latest',
+				package: 'react',
+				version: 'latest',
+				resourcesDirectoryPath: testDir,
+				specialAgentInstructions: '',
+				quiet: true
+			},
+			npmDeps
+		);
+
+		const { result, vfsId } = await materializeResource(resource, '/react-latest');
+		try {
+			expect(result.metadata.version).toBe('19.1.0');
+
+			const meta = JSON.parse(
+				await Bun.file(path.join(testDir, 'react-latest', '.btca-npm-meta.json')).text()
+			) as { requestedVersion?: string; resolvedVersion: string };
+			expect(meta.requestedVersion).toBe('latest');
+			expect(meta.resolvedVersion).toBe('19.1.0');
 		} finally {
 			disposeVirtualFs(vfsId);
 		}
@@ -413,6 +466,73 @@ describe('NPM Resource', () => {
 		const resource = await loadNpmResource(args, npmDeps);
 		await expect(materializeResource(resource, '/react-docs-error')).rejects.toThrow(
 			'Failed to install npm package "react@19.0.0"'
+		);
+	});
+
+	it('does not publish cache metadata when payload writes fail', async () => {
+		const npmDeps = createNpmTestDeps(createInstallSpawnMock());
+		globalThis.fetch = (async (input) => {
+			const url = String(input);
+			if (url.startsWith('https://registry.npmjs.org/react')) {
+				return new Response(
+					JSON.stringify({
+						'dist-tags': { latest: '19.0.0' },
+						versions: {
+							'19.0.0': {
+								name: 'react',
+								version: '19.0.0',
+								description: 'React',
+								readme: '# React\n\nDocs'
+							}
+						}
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } }
+				);
+			}
+			if (url.startsWith('https://www.npmjs.com/package/react/v/19.0.0')) {
+				return new Response('<html><title>react</title></html>', { status: 200 });
+			}
+			return new Response('not found', { status: 404 });
+		}) as typeof fetch;
+
+		const originalWrite = Bun.write.bind(Bun);
+		const writeSpy = jest.spyOn(Bun, 'write').mockImplementation(async (...writeArgs) => {
+			const target = writeArgs[0];
+			if (
+				typeof target === 'string' &&
+				target.endsWith(path.join('react-docs', 'npm-package-page.html'))
+			) {
+				throw new Error('page write failed');
+			}
+			return originalWrite(
+				writeArgs[0] as Parameters<typeof Bun.write>[0],
+				writeArgs[1] as Parameters<typeof Bun.write>[1],
+				writeArgs[2] as Parameters<typeof Bun.write>[2]
+			);
+		});
+
+		try {
+			const resource = await loadNpmResource(
+				{
+					type: 'npm',
+					name: 'react-docs',
+					package: 'react',
+					resourcesDirectoryPath: testDir,
+					specialAgentInstructions: '',
+					quiet: true
+				},
+				npmDeps
+			);
+
+			await expect(materializeResource(resource, '/react-docs-error')).rejects.toThrow(
+				'page write failed'
+			);
+		} finally {
+			writeSpy.mockRestore();
+		}
+
+		expect(await Bun.file(path.join(testDir, 'react-docs', '.btca-npm-meta.json')).exists()).toBe(
+			false
 		);
 	});
 });

--- a/apps/server/src/resources/impls/npm.test.ts
+++ b/apps/server/src/resources/impls/npm.test.ts
@@ -4,8 +4,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { loadNpmResource } from './npm.ts';
+import { loadNpmResource, type NpmResourceDeps } from './npm.ts';
 import type { BtcaNpmResourceArgs } from '../types.ts';
+import { createVirtualFs, disposeVirtualFs } from '../../vfs/virtual-fs.ts';
 
 const streamFromString = (value: string) =>
 	new ReadableStream<Uint8Array>({
@@ -56,25 +57,40 @@ const createInstallSpawnMock = (args?: { exitCode?: number; stdout?: string; std
 		} as unknown as ReturnType<typeof Bun.spawn>;
 	}) as typeof Bun.spawn;
 
+const createNpmTestDeps = (spawn: NpmResourceDeps['spawn']): Partial<NpmResourceDeps> => ({
+	spawn
+});
+
+const materializeResource = async (
+	resource: Awaited<ReturnType<typeof loadNpmResource>>,
+	destinationPath = '/resource'
+) => {
+	const vfsId = createVirtualFs();
+	try {
+		const result = await resource.materializeIntoVirtualFs({ destinationPath, vfsId });
+		return { result, vfsId };
+	} catch (cause) {
+		disposeVirtualFs(vfsId);
+		throw cause;
+	}
+};
+
 describe('NPM Resource', () => {
 	let testDir: string;
 	let originalFetch: typeof fetch;
-	let originalSpawn: typeof Bun.spawn;
 
 	beforeEach(async () => {
 		testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-npm-test-'));
 		originalFetch = globalThis.fetch;
-		originalSpawn = Bun.spawn;
 	});
 
 	afterEach(async () => {
 		globalThis.fetch = originalFetch;
-		Bun.spawn = originalSpawn;
 		await fs.rm(testDir, { recursive: true, force: true });
 	});
 
 	it('hydrates an npm package into a filesystem resource', async () => {
-		Bun.spawn = createInstallSpawnMock();
+		const npmDeps = createNpmTestDeps(createInstallSpawnMock());
 		globalThis.fetch = (async (input) => {
 			const url = String(input);
 			if (url.startsWith('https://registry.npmjs.org/react')) {
@@ -104,34 +120,40 @@ describe('NPM Resource', () => {
 			name: 'react-docs',
 			package: 'react',
 			resourcesDirectoryPath: testDir,
-			specialAgentInstructions: 'Use this for React questions'
+			specialAgentInstructions: 'Use this for React questions',
+			quiet: true
 		};
 
-		const resource = await loadNpmResource(args);
+		const resource = await loadNpmResource(args, npmDeps);
 		expect(resource._tag).toBe('fs-based');
 		expect(resource.type).toBe('npm');
 		expect(resource.repoSubPaths).toEqual([]);
 
-		const resourcePath = await resource.getAbsoluteDirectoryPath();
-		expect(resourcePath).toBe(path.join(testDir, 'react-docs'));
+		const { result, vfsId } = await materializeResource(resource, '/react-docs');
+		const resourcePath = path.join(testDir, 'react-docs');
+		expect(result.metadata.package).toBe('react');
 
-		const readme = await Bun.file(path.join(resourcePath, 'README.md')).text();
-		expect(readme).toContain('# React');
-		const runtimeFile = await Bun.file(path.join(resourcePath, 'src', 'runtime.js')).text();
-		expect(runtimeFile).toContain(`'$state'`);
+		try {
+			const readme = await Bun.file(path.join(resourcePath, 'README.md')).text();
+			expect(readme).toContain('# React');
+			const runtimeFile = await Bun.file(path.join(resourcePath, 'src', 'runtime.js')).text();
+			expect(runtimeFile).toContain(`'$state'`);
 
-		const packagePage = await Bun.file(path.join(resourcePath, 'npm-package-page.html')).text();
-		expect(packagePage).toContain('<title>react</title>');
+			const packagePage = await Bun.file(path.join(resourcePath, 'npm-package-page.html')).text();
+			expect(packagePage).toContain('<title>react</title>');
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
 	});
 
 	it('reuses cached pinned versions without refetching', async () => {
 		let fetchCalls = 0;
 		let spawnCalls = 0;
 		const installSpawnMock = createInstallSpawnMock();
-		Bun.spawn = ((...spawnArgs: Parameters<typeof Bun.spawn>) => {
+		const npmDeps = createNpmTestDeps(((...spawnArgs: Parameters<typeof Bun.spawn>) => {
 			spawnCalls += 1;
 			return installSpawnMock(...spawnArgs);
-		}) as typeof Bun.spawn;
+		}) as typeof Bun.spawn);
 		globalThis.fetch = (async (input) => {
 			fetchCalls += 1;
 			const url = String(input);
@@ -162,19 +184,24 @@ describe('NPM Resource', () => {
 			package: '@types/node',
 			version: '22.10.1',
 			resourcesDirectoryPath: testDir,
-			specialAgentInstructions: ''
+			specialAgentInstructions: '',
+			quiet: true
 		};
 
-		await loadNpmResource(args);
+		const first = await loadNpmResource(args, npmDeps);
+		const firstMaterialized = await materializeResource(first, '/node-types-a');
+		disposeVirtualFs(firstMaterialized.vfsId);
 		const firstFetchCalls = fetchCalls;
 		const firstSpawnCalls = spawnCalls;
-		await loadNpmResource(args);
+		const second = await loadNpmResource(args, npmDeps);
+		const secondMaterialized = await materializeResource(second, '/node-types-b');
+		disposeVirtualFs(secondMaterialized.vfsId);
 		expect(fetchCalls).toBe(firstFetchCalls);
 		expect(spawnCalls).toBe(firstSpawnCalls);
 	});
 
 	it('adds cleanup for anonymous npm resources', async () => {
-		Bun.spawn = createInstallSpawnMock();
+		const npmDeps = createNpmTestDeps(createInstallSpawnMock());
 		globalThis.fetch = (async (input) => {
 			const url = String(input);
 			if (url.startsWith('https://registry.npmjs.org/react')) {
@@ -200,14 +227,17 @@ describe('NPM Resource', () => {
 			package: 'react',
 			resourcesDirectoryPath: testDir,
 			specialAgentInstructions: '',
+			quiet: true,
 			ephemeral: true,
 			localDirectoryKey: 'anonymous-react'
 		};
 
-		const resource = await loadNpmResource(args);
+		const resource = await loadNpmResource(args, npmDeps);
 		expect(resource.cleanup).toBeDefined();
 
-		const resourcePath = await resource.getAbsoluteDirectoryPath();
+		const materialized = await materializeResource(resource, '/anonymous-react');
+		disposeVirtualFs(materialized.vfsId);
+		const resourcePath = path.join(testDir, '.tmp', 'anonymous-react');
 		let existsBefore = false;
 		try {
 			await fs.stat(resourcePath);
@@ -229,7 +259,7 @@ describe('NPM Resource', () => {
 	});
 
 	it('uses readable fsName aliases for anonymous npm resources', async () => {
-		Bun.spawn = createInstallSpawnMock();
+		const npmDeps = createNpmTestDeps(createInstallSpawnMock());
 		globalThis.fetch = (async (input) => {
 			const url = String(input);
 			if (url.startsWith('https://registry.npmjs.org/%40types%2Fnode')) {
@@ -256,18 +286,48 @@ describe('NPM Resource', () => {
 			version: '22.10.1',
 			resourcesDirectoryPath: testDir,
 			specialAgentInstructions: '',
+			quiet: true,
 			ephemeral: true,
 			localDirectoryKey: 'anonymous-types-node'
 		};
 
-		const resource = await loadNpmResource(args);
-		expect(resource.fsName).toBe('npm:@types__node@22.10.1');
+		const resource = await loadNpmResource(args, npmDeps);
+		expect(resource.fsName).toBe('npm:@types__node@22.10.1--anonymous-types-node');
 		expect(resource.fsName.includes('%3A')).toBe(false);
 		expect(resource.fsName.includes('%2F')).toBe(false);
 	});
 
+	it('keeps anonymous npm fsName values collision-free for distinct packages with similar sanitized names', async () => {
+		const first = await loadNpmResource({
+			type: 'npm',
+			name: 'anonymous:npm:@foo/bar__baz@1.0.0',
+			package: '@foo/bar__baz',
+			version: '1.0.0',
+			resourcesDirectoryPath: testDir,
+			specialAgentInstructions: '',
+			quiet: true,
+			ephemeral: true,
+			localDirectoryKey: 'anonymous-first'
+		});
+		const second = await loadNpmResource({
+			type: 'npm',
+			name: 'anonymous:npm:@foo__bar/baz@1.0.0',
+			package: '@foo__bar/baz',
+			version: '1.0.0',
+			resourcesDirectoryPath: testDir,
+			specialAgentInstructions: '',
+			quiet: true,
+			ephemeral: true,
+			localDirectoryKey: 'anonymous-second'
+		});
+
+		expect(first.fsName).not.toBe(second.fsName);
+		expect(first.fsName).toContain('anonymous-first');
+		expect(second.fsName).toContain('anonymous-second');
+	});
+
 	it('continues when npm package page fetch is unavailable', async () => {
-		Bun.spawn = createInstallSpawnMock();
+		const npmDeps = createNpmTestDeps(createInstallSpawnMock());
 		globalThis.fetch = (async (input) => {
 			const url = String(input);
 			if (url.startsWith('https://registry.npmjs.org/react')) {
@@ -296,20 +356,28 @@ describe('NPM Resource', () => {
 			name: 'react-docs',
 			package: 'react',
 			resourcesDirectoryPath: testDir,
-			specialAgentInstructions: ''
+			specialAgentInstructions: '',
+			quiet: true
 		};
 
-		const resource = await loadNpmResource(args);
-		const resourcePath = await resource.getAbsoluteDirectoryPath();
-		const packagePage = await Bun.file(path.join(resourcePath, 'npm-package-page.html')).text();
-		expect(packagePage).toContain('npm package page unavailable');
+		const resource = await loadNpmResource(args, npmDeps);
+		const { vfsId } = await materializeResource(resource, '/react-docs-fallback');
+		try {
+			const resourcePath = path.join(testDir, 'react-docs');
+			const packagePage = await Bun.file(path.join(resourcePath, 'npm-package-page.html')).text();
+			expect(packagePage).toContain('npm package page unavailable');
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
 	});
 
 	it('returns a clear install error when bun install fails', async () => {
-		Bun.spawn = createInstallSpawnMock({
-			exitCode: 1,
-			stderr: 'error: package not found'
-		});
+		const npmDeps = createNpmTestDeps(
+			createInstallSpawnMock({
+				exitCode: 1,
+				stderr: 'error: package not found'
+			})
+		);
 		globalThis.fetch = (async (input) => {
 			const url = String(input);
 			if (url.startsWith('https://registry.npmjs.org/react')) {
@@ -338,10 +406,12 @@ describe('NPM Resource', () => {
 			name: 'react-docs',
 			package: 'react',
 			resourcesDirectoryPath: testDir,
-			specialAgentInstructions: ''
+			specialAgentInstructions: '',
+			quiet: true
 		};
 
-		await expect(loadNpmResource(args)).rejects.toThrow(
+		const resource = await loadNpmResource(args, npmDeps);
+		await expect(materializeResource(resource, '/react-docs-error')).rejects.toThrow(
 			'Failed to install npm package "react@19.0.0"'
 		);
 	});

--- a/apps/server/src/resources/impls/npm.ts
+++ b/apps/server/src/resources/impls/npm.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
@@ -312,6 +313,19 @@ const readCacheMeta = async (localPath: string): Promise<NpmCacheMeta | null> =>
 	}
 };
 
+const writeCacheMetaAtomically = async (localPath: string, meta: NpmCacheMeta) => {
+	const targetPath = path.join(localPath, NPM_CACHE_META_FILE);
+	const tempPath = `${targetPath}.${randomUUID()}.tmp`;
+
+	try {
+		await Bun.write(tempPath, JSON.stringify(meta, null, 2));
+		await fs.rename(tempPath, targetPath);
+	} catch (cause) {
+		await fs.rm(tempPath, { force: true }).catch(() => undefined);
+		throw cause;
+	}
+};
+
 const shouldReuseCache = async (config: ResolvedNpmResourceArgs): Promise<boolean> => {
 	const localPath = config.localPath;
 	if (!config.requestedVersion || config.ephemeral) return false;
@@ -429,9 +443,9 @@ const writeNpmMetadataFiles = async (args: {
 
 	await Promise.all([
 		Bun.write(path.join(args.localPath, NPM_CONTENT_FILE), overview),
-		Bun.write(path.join(args.localPath, NPM_PAGE_FILE), args.pageHtml),
-		Bun.write(path.join(args.localPath, NPM_CACHE_META_FILE), JSON.stringify(meta, null, 2))
+		Bun.write(path.join(args.localPath, NPM_PAGE_FILE), args.pageHtml)
 	]);
+	await writeCacheMetaAtomically(args.localPath, meta);
 };
 
 const hydrateNpmResource = async (config: ResolvedNpmResourceArgs, deps: NpmResourceDeps) => {
@@ -570,7 +584,7 @@ export const loadNpmResource = async (
 					return {
 						metadata: {
 							package: resolved.package,
-							version: resolved.requestedVersion ?? cached?.resolvedVersion,
+							version: cached?.resolvedVersion ?? resolved.requestedVersion,
 							url: cached?.packageUrl
 						}
 					};

--- a/apps/server/src/resources/impls/npm.ts
+++ b/apps/server/src/resources/impls/npm.ts
@@ -1,11 +1,14 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { importDirectoryIntoVirtualFs } from '../../vfs/virtual-fs.ts';
 import { CommonHints } from '../../errors.ts';
-import { ResourceError, resourceNameToKey } from '../helpers.ts';
-import type { BtcaFsResource, BtcaNpmResourceArgs } from '../types.ts';
+import { cleanupDirectory, directoryExists } from '../fs-utils.ts';
+import { ResourceError, resourceNameToKey, shouldIgnoreCommonImportedPath } from '../helpers.ts';
+import { withClearAwareFilesystemLock, withFilesystemLock } from '../lock.ts';
+import { TMP_DIR, getClearLockPath, getNpmLockPath } from '../layout.ts';
+import type { BtcaNpmFsResource, BtcaNpmResourceArgs } from '../types.ts';
 
-const ANONYMOUS_CLONE_DIR = '.tmp';
 const NPM_INSTALL_STAGING_DIR = '.btca-install';
 const NPM_CACHE_META_FILE = '.btca-npm-meta.json';
 const NPM_CONTENT_FILE = 'npm-package.md';
@@ -39,21 +42,67 @@ type NpmPackageVersion = {
 	readonly peerDependencies?: Record<string, string | undefined>;
 };
 
-const cleanupDirectory = async (pathToRemove: string) => {
-	try {
-		await fs.rm(pathToRemove, { recursive: true, force: true });
-	} catch {
-		return;
-	}
+type BunSpawnLike = typeof Bun.spawn;
+
+export type NpmResourceDeps = {
+	readonly spawn: BunSpawnLike;
 };
 
-const directoryExists = async (directoryPath: string) => {
-	try {
-		const stat = await fs.stat(directoryPath);
-		return stat.isDirectory();
-	} catch {
-		return false;
+type ResolvedNpmResourceArgs = {
+	readonly name: string;
+	readonly fsName: string;
+	readonly cacheKey: string;
+	readonly package: string;
+	readonly requestedVersion?: string;
+	readonly resourcesDirectoryPath: string;
+	readonly specialAgentInstructions: string;
+	readonly quiet: boolean;
+	readonly ephemeral: boolean;
+	readonly localPath: string;
+	readonly clearLockPath: string;
+	readonly resourceLockPath: string;
+};
+
+const sanitizeNpmCitationSegment = (value: string) =>
+	value
+		.trim()
+		.replace(/\//g, '__')
+		.replace(/[^a-zA-Z0-9._@+-]+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+
+const getResolvedNpmFsName = (config: BtcaNpmResourceArgs) => {
+	if (!config.ephemeral || !config.name.startsWith('anonymous:npm:')) {
+		return resourceNameToKey(config.name);
 	}
+
+	const packageSegment = sanitizeNpmCitationSegment(config.package);
+	const versionSegment = sanitizeNpmCitationSegment(config.version ?? 'latest');
+	const cacheSuffix = config.localDirectoryKey ?? resourceNameToKey(config.name);
+	return `npm:${packageSegment}@${versionSegment}--${cacheSuffix}`;
+};
+
+const resolveNpmResourceArgs = (config: BtcaNpmResourceArgs): ResolvedNpmResourceArgs => {
+	const cacheKey = config.localDirectoryKey ?? resourceNameToKey(config.name);
+	const localBasePath =
+		config.ephemeral === true
+			? path.join(config.resourcesDirectoryPath, TMP_DIR)
+			: config.resourcesDirectoryPath;
+
+	return {
+		name: config.name,
+		fsName: getResolvedNpmFsName(config),
+		cacheKey,
+		package: config.package,
+		...(config.version ? { requestedVersion: config.version } : {}),
+		resourcesDirectoryPath: config.resourcesDirectoryPath,
+		specialAgentInstructions: config.specialAgentInstructions,
+		quiet: config.quiet,
+		ephemeral: config.ephemeral ?? false,
+		localPath: path.join(localBasePath, cacheKey),
+		clearLockPath: getClearLockPath(config.resourcesDirectoryPath),
+		resourceLockPath: getNpmLockPath(config.resourcesDirectoryPath, cacheKey)
+	};
 };
 
 const encodePackagePath = (packageName: string) =>
@@ -166,14 +215,26 @@ const readProcessOutput = async (stream: ReadableStream<Uint8Array> | null) => {
 	return new TextDecoder().decode(merged);
 };
 
-const runBunInstall = async (args: {
-	installDirectory: string;
-	packageName: string;
-	resolvedVersion: string;
-}) => {
+const defaultNpmResourceDeps: NpmResourceDeps = {
+	spawn: ((...spawnArgs: Parameters<typeof Bun.spawn>) =>
+		Bun.spawn(...spawnArgs)) as typeof Bun.spawn
+};
+
+const resolveNpmResourceDeps = (deps?: Partial<NpmResourceDeps>): NpmResourceDeps => ({
+	spawn: deps?.spawn ?? defaultNpmResourceDeps.spawn
+});
+
+const runBunInstall = async (
+	args: {
+		installDirectory: string;
+		packageName: string;
+		resolvedVersion: string;
+	},
+	deps: NpmResourceDeps
+) => {
 	const packageSpec = `${args.packageName}@${args.resolvedVersion}`;
 	const command = ['bun', 'add', '--exact', '--ignore-scripts', packageSpec];
-	const process = Bun.spawn(command, {
+	const process = deps.spawn(command, {
 		cwd: args.installDirectory,
 		stdout: 'pipe',
 		stderr: 'pipe'
@@ -251,11 +312,9 @@ const readCacheMeta = async (localPath: string): Promise<NpmCacheMeta | null> =>
 	}
 };
 
-const shouldReuseCache = async (
-	config: BtcaNpmResourceArgs,
-	localPath: string
-): Promise<boolean> => {
-	if (!config.version || config.ephemeral) return false;
+const shouldReuseCache = async (config: ResolvedNpmResourceArgs): Promise<boolean> => {
+	const localPath = config.localPath;
+	if (!config.requestedVersion || config.ephemeral) return false;
 	const exists = await directoryExists(localPath);
 	if (!exists) return false;
 
@@ -263,16 +322,19 @@ const shouldReuseCache = async (
 	if (!cached) return false;
 	return (
 		cached.packageName === config.package &&
-		cached.requestedVersion === config.version &&
+		cached.requestedVersion === config.requestedVersion &&
 		cached.resolvedVersion.length > 0
 	);
 };
 
-const installPackageFiles = async (args: {
-	localPath: string;
-	packageName: string;
-	resolvedVersion: string;
-}) => {
+const installPackageFiles = async (
+	args: {
+		localPath: string;
+		packageName: string;
+		resolvedVersion: string;
+	},
+	deps: NpmResourceDeps
+) => {
 	const installDirectory = path.join(args.localPath, NPM_INSTALL_STAGING_DIR);
 	const packagePath = path.join(installDirectory, 'node_modules', ...args.packageName.split('/'));
 
@@ -307,11 +369,14 @@ const installPackageFiles = async (args: {
 	}
 
 	try {
-		await runBunInstall({
-			installDirectory,
-			packageName: args.packageName,
-			resolvedVersion: args.resolvedVersion
-		});
+		await runBunInstall(
+			{
+				installDirectory,
+				packageName: args.packageName,
+				resolvedVersion: args.resolvedVersion
+			},
+			deps
+		);
 
 		const hasInstalledPackage = await directoryExists(packagePath);
 		if (!hasInstalledPackage) {
@@ -369,10 +434,11 @@ const writeNpmMetadataFiles = async (args: {
 	]);
 };
 
-const hydrateNpmResource = async (config: BtcaNpmResourceArgs, localPath: string) => {
+const hydrateNpmResource = async (config: ResolvedNpmResourceArgs, deps: NpmResourceDeps) => {
+	const localPath = config.localPath;
 	const packagePath = encodePackagePath(config.package);
 	const registryUrl = `${NPM_REGISTRY_HOST}/${encodeURIComponent(config.package)}`;
-	const requestedVersion = config.version?.trim();
+	const requestedVersion = config.requestedVersion?.trim();
 	const packument = await fetchJson<NpmPackument>(registryUrl, config.name);
 	const resolvedVersion = resolveRequestedVersion(packument, requestedVersion);
 
@@ -397,11 +463,14 @@ const hydrateNpmResource = async (config: BtcaNpmResourceArgs, localPath: string
 	const pageUrl = `${packageUrl}/v/${encodeURIComponent(resolvedVersion)}`;
 	const pageHtml = await fetchText(pageUrl, config.name);
 
-	await installPackageFiles({
-		localPath,
-		packageName: config.package,
-		resolvedVersion
-	});
+	await installPackageFiles(
+		{
+			localPath,
+			packageName: config.package,
+			resolvedVersion
+		},
+		deps
+	);
 
 	await writeNpmMetadataFiles({
 		localPath,
@@ -415,12 +484,12 @@ const hydrateNpmResource = async (config: BtcaNpmResourceArgs, localPath: string
 	});
 };
 
-const ensureNpmResource = async (config: BtcaNpmResourceArgs): Promise<string> => {
-	const resourceKey = config.localDirectoryKey ?? resourceNameToKey(config.name);
-	const basePath = config.ephemeral
-		? path.join(config.resourcesDirectoryPath, ANONYMOUS_CLONE_DIR)
-		: config.resourcesDirectoryPath;
-	const localPath = path.join(basePath, resourceKey);
+const ensureNpmResource = async (
+	config: ResolvedNpmResourceArgs,
+	deps: NpmResourceDeps
+): Promise<string> => {
+	const localPath = config.localPath;
+	const basePath = path.dirname(localPath);
 
 	try {
 		await fs.mkdir(basePath, { recursive: true });
@@ -432,7 +501,7 @@ const ensureNpmResource = async (config: BtcaNpmResourceArgs): Promise<string> =
 		});
 	}
 
-	const canReuse = await shouldReuseCache(config, localPath);
+	const canReuse = await shouldReuseCache(config);
 	if (canReuse) return localPath;
 
 	await cleanupDirectory(localPath);
@@ -446,44 +515,68 @@ const ensureNpmResource = async (config: BtcaNpmResourceArgs): Promise<string> =
 		});
 	}
 
-	await hydrateNpmResource(config, localPath);
+	await hydrateNpmResource(config, deps);
 	return localPath;
 };
 
-const sanitizeNpmCitationSegment = (value: string) =>
-	value
-		.trim()
-		.replace(/\//g, '__')
-		.replace(/[^a-zA-Z0-9._@+-]+/g, '-')
-		.replace(/-+/g, '-')
-		.replace(/^-|-$/g, '');
-
-const getNpmFsName = (config: BtcaNpmResourceArgs) => {
-	if (!config.ephemeral || !config.name.startsWith('anonymous:npm:')) {
-		return resourceNameToKey(config.name);
-	}
-
-	const packageSegment = sanitizeNpmCitationSegment(config.package);
-	const versionSegment = sanitizeNpmCitationSegment(config.version ?? 'latest');
-	return `npm:${packageSegment}@${versionSegment}`;
-};
-
-export const loadNpmResource = async (config: BtcaNpmResourceArgs): Promise<BtcaFsResource> => {
-	const localPath = await ensureNpmResource(config);
-	const cleanup = config.ephemeral
+export const loadNpmResource = async (
+	config: BtcaNpmResourceArgs,
+	deps?: Partial<NpmResourceDeps>
+): Promise<BtcaNpmFsResource> => {
+	const resolved = resolveNpmResourceArgs(config);
+	const npmDeps = resolveNpmResourceDeps(deps);
+	const cleanup = resolved.ephemeral
 		? async () => {
-				await cleanupDirectory(localPath);
+				await withFilesystemLock(
+					{
+						lockPath: resolved.resourceLockPath,
+						label: `npm.cleanup.${resolved.cacheKey}`,
+						quiet: resolved.quiet
+					},
+					async () => {
+						await cleanupDirectory(resolved.localPath);
+					}
+				);
 			}
 		: undefined;
 
 	return {
 		_tag: 'fs-based',
-		name: config.name,
-		fsName: getNpmFsName(config),
+		name: resolved.name,
+		fsName: resolved.fsName,
 		type: 'npm',
 		repoSubPaths: [],
-		specialAgentInstructions: config.specialAgentInstructions,
-		getAbsoluteDirectoryPath: async () => localPath,
+		specialAgentInstructions: resolved.specialAgentInstructions,
+		materializeIntoVirtualFs: async ({ destinationPath, vfsId }) => {
+			return withClearAwareFilesystemLock(
+				{
+					clearLockPath: resolved.clearLockPath,
+					clearLockWaitLabel: `wait-clear-before-npm.${resolved.cacheKey}`,
+					clearLockInspectLabel: `inspect-clear-before-npm.${resolved.cacheKey}`,
+					resourceLockPath: resolved.resourceLockPath,
+					resourceLockLabel: `npm.${resolved.cacheKey}`,
+					quiet: resolved.quiet
+				},
+				async () => {
+					const materializedPath = await ensureNpmResource(resolved, npmDeps);
+					await importDirectoryIntoVirtualFs({
+						sourcePath: materializedPath,
+						destinationPath,
+						vfsId,
+						ignore: shouldIgnoreCommonImportedPath
+					});
+
+					const cached = await readCacheMeta(materializedPath);
+					return {
+						metadata: {
+							package: resolved.package,
+							version: resolved.requestedVersion ?? cached?.resolvedVersion,
+							url: cached?.packageUrl
+						}
+					};
+				}
+			);
+		},
 		...(cleanup ? { cleanup } : {})
 	};
 };

--- a/apps/server/src/resources/impls/test-fixtures/git-materialize-worker.ts
+++ b/apps/server/src/resources/impls/test-fixtures/git-materialize-worker.ts
@@ -1,0 +1,59 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { disposeVirtualFs, createVirtualFs } from '../../../vfs/virtual-fs.ts';
+import { loadGitResource } from '../git.ts';
+
+type WorkerPayload = {
+	readonly gitBinDir?: string;
+	readonly resourcesDirectory: string;
+	readonly name: string;
+	readonly url: string;
+	readonly branch: string;
+	readonly repoSubPaths?: readonly string[];
+	readonly ephemeral?: boolean;
+	readonly localDirectoryKey?: string;
+	readonly quiet?: boolean;
+	readonly cleanupAfter?: boolean;
+	readonly pauseAfterMs?: number;
+};
+
+const payloadText = process.env.BTCA_WORKER_PAYLOAD;
+if (!payloadText) {
+	console.error('BTCA_WORKER_PAYLOAD is required');
+	process.exit(1);
+}
+
+const payload = JSON.parse(payloadText) as WorkerPayload;
+if (payload.gitBinDir) {
+	process.env.PATH = `${payload.gitBinDir}:${process.env.PATH ?? ''}`;
+}
+
+const resource = await loadGitResource({
+	type: 'git',
+	name: payload.name,
+	url: payload.url,
+	branch: payload.branch,
+	repoSubPaths: payload.repoSubPaths ?? [],
+	resourcesDirectoryPath: payload.resourcesDirectory,
+	specialAgentInstructions: '',
+	quiet: payload.quiet ?? true,
+	...(payload.localDirectoryKey ? { localDirectoryKey: payload.localDirectoryKey } : {}),
+	...(payload.ephemeral ? { ephemeral: true } : {})
+});
+
+const vfsId = createVirtualFs();
+try {
+	const result = await resource.materializeIntoVirtualFs({
+		destinationPath: '/resource',
+		vfsId
+	});
+	if (payload.pauseAfterMs) {
+		await sleep(payload.pauseAfterMs);
+	}
+	if (payload.cleanupAfter) {
+		await resource.cleanup?.();
+	}
+	console.log(JSON.stringify(result));
+} finally {
+	disposeVirtualFs(vfsId);
+}

--- a/apps/server/src/resources/impls/test-fixtures/npm-materialize-worker.ts
+++ b/apps/server/src/resources/impls/test-fixtures/npm-materialize-worker.ts
@@ -1,0 +1,271 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import type { NpmResourceDeps } from '../npm.ts';
+import { setFilesystemLockTestHookForTests, type FilesystemLockTestEvent } from '../../lock.ts';
+import { createResourcesService } from '../../service.ts';
+import type { ResourceDefinition } from '../../schema.ts';
+import { createConfigServiceMock } from '../../test-support.ts';
+import { createVirtualFs, disposeVirtualFs } from '../../../vfs/virtual-fs.ts';
+
+type WorkerAction =
+	| {
+			readonly type: 'materialize';
+			readonly reference: string;
+			readonly destinationPath?: string;
+	  }
+	| {
+			readonly type: 'cleanup';
+			readonly reference: string;
+	  }
+	| {
+			readonly type: 'clear';
+	  };
+
+type WorkerMockConfig = {
+	readonly packageName: string;
+	readonly resolvedVersion: string;
+	readonly pageHtml?: string;
+	readonly holdInstallUntilContinue?: boolean;
+	readonly exitCode?: number;
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly exitBeforeResult?: boolean;
+};
+
+type WorkerConfig = {
+	readonly resourcesDirectory: string;
+	readonly resources: readonly ResourceDefinition[];
+	readonly action: WorkerAction;
+	readonly mock: WorkerMockConfig;
+};
+
+type ChildToParentMessage =
+	| {
+			readonly type: 'install-started';
+			readonly packageSpec: string;
+			readonly cwd?: string;
+	  }
+	| {
+			readonly type: 'lock-event';
+			readonly event: FilesystemLockTestEvent;
+	  }
+	| {
+			readonly type: 'result';
+			readonly result: unknown;
+	  }
+	| {
+			readonly type: 'error';
+			readonly message: string;
+	  };
+
+const streamFromString = (value: string) =>
+	new ReadableStream<Uint8Array>({
+		start(controller) {
+			if (value.length > 0) controller.enqueue(new TextEncoder().encode(value));
+			controller.close();
+		}
+	});
+
+const parsePackageSpec = (value: string) => {
+	const splitIndex = value.lastIndexOf('@');
+	if (splitIndex <= 0 || splitIndex === value.length - 1) {
+		return { packageName: value, version: '0.0.0' };
+	}
+	return {
+		packageName: value.slice(0, splitIndex),
+		version: value.slice(splitIndex + 1)
+	};
+};
+
+const encodePackagePath = (packageName: string) =>
+	packageName.split('/').map(encodeURIComponent).join('/');
+
+const waitForContinueInstall = async (timeoutMs = 30_000) => {
+	await new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			process.off('message', onMessage);
+			reject(new Error('Timed out waiting for continue-install IPC message'));
+		}, timeoutMs);
+
+		const onMessage = (message: unknown) => {
+			if (!message || typeof message !== 'object') return;
+			const type = Reflect.get(message, 'type');
+			if (type !== 'continue-install') return;
+			clearTimeout(timer);
+			process.off('message', onMessage);
+			resolve();
+		};
+
+		process.on('message', onMessage);
+	});
+};
+
+const sendWorkerMessage = (message: ChildToParentMessage) => {
+	process.send?.(message);
+};
+
+const installPackageIntoCwd = (cwd: string, packageName: string, version: string) => {
+	const packageDirectory = path.join(cwd, 'node_modules', ...packageName.split('/'));
+	mkdirSync(path.join(packageDirectory, 'src'), { recursive: true });
+	const title = packageName === 'react' ? 'React' : packageName;
+	writeFileSync(path.join(packageDirectory, 'README.md'), `# ${title}\n\nInstalled for btca`);
+	writeFileSync(
+		path.join(packageDirectory, 'package.json'),
+		JSON.stringify({ name: packageName, version }, null, 2)
+	);
+	writeFileSync(path.join(packageDirectory, 'src', 'runtime.js'), `export const rune = '$state';`);
+};
+
+const installMock = (mock: WorkerMockConfig) =>
+	((...spawnArgs: Parameters<typeof Bun.spawn>) => {
+		const [command, options] = spawnArgs;
+		const commandArgs = Array.isArray(command) ? command : [command];
+		const packageSpec = commandArgs.at(-1) ?? '';
+		const { packageName, version } = parsePackageSpec(packageSpec);
+		const cwd = options?.cwd;
+
+		const exited = (async () => {
+			if (mock.holdInstallUntilContinue) {
+				sendWorkerMessage({
+					type: 'install-started',
+					packageSpec,
+					...(typeof cwd === 'string' ? { cwd } : {})
+				});
+				await waitForContinueInstall();
+			}
+			if ((mock.exitCode ?? 0) === 0 && cwd) {
+				installPackageIntoCwd(cwd, packageName, version);
+			}
+			return mock.exitCode ?? 0;
+		})();
+
+		return {
+			stdout: streamFromString(mock.stdout ?? ''),
+			stderr: streamFromString(mock.stderr ?? ''),
+			exited
+		} as unknown as ReturnType<typeof Bun.spawn>;
+	}) as typeof Bun.spawn;
+
+const createFetchMock = (mock: WorkerMockConfig) =>
+	(async (input: string | URL | Request) => {
+		const url = String(input);
+		const registryUrl = `https://registry.npmjs.org/${encodeURIComponent(mock.packageName)}`;
+		const pageUrl = `https://www.npmjs.com/package/${encodePackagePath(mock.packageName)}/v/${encodeURIComponent(mock.resolvedVersion)}`;
+
+		if (url.startsWith(registryUrl)) {
+			return new Response(
+				JSON.stringify({
+					'dist-tags': { latest: mock.resolvedVersion },
+					versions: {
+						[mock.resolvedVersion]: {
+							name: mock.packageName,
+							version: mock.resolvedVersion,
+							description: mock.packageName === 'react' ? 'React' : mock.packageName,
+							readme: `# ${mock.packageName}`
+						}
+					}
+				}),
+				{ status: 200, headers: { 'content-type': 'application/json' } }
+			);
+		}
+
+		if (url.startsWith(pageUrl)) {
+			return new Response(mock.pageHtml ?? `<html><title>${mock.packageName}</title></html>`, {
+				status: 200
+			});
+		}
+
+		return new Response('not found', { status: 404 });
+	}) as typeof fetch;
+
+const run = async (config: WorkerConfig) => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = createFetchMock(config.mock);
+	const npmDeps: Partial<NpmResourceDeps> = {
+		spawn: installMock(config.mock)
+	};
+	setFilesystemLockTestHookForTests((event) => {
+		sendWorkerMessage({
+			type: 'lock-event',
+			event
+		});
+	});
+
+	try {
+		const service = createResourcesService(
+			createConfigServiceMock({
+				resourcesDirectory: config.resourcesDirectory,
+				resources: config.resources
+			}),
+			{ npm: npmDeps }
+		);
+
+		if (config.action.type === 'clear') {
+			return await service.clearCachesPromise();
+		}
+
+		const resource = await service.loadPromise(config.action.reference, { quiet: true });
+		if (config.action.type === 'cleanup') {
+			if (!resource.cleanup) {
+				throw new Error(`Resource "${config.action.reference}" does not expose cleanup()`);
+			}
+			await resource.cleanup();
+			return { cleaned: true, name: resource.name };
+		}
+
+		const vfsId = createVirtualFs();
+		try {
+			const materialized = await resource.materializeIntoVirtualFs({
+				destinationPath: config.action.destinationPath ?? '/resource',
+				vfsId
+			});
+			return {
+				name: resource.name,
+				fsName: resource.fsName,
+				metadata: materialized.metadata,
+				hasCleanup: Boolean(resource.cleanup)
+			};
+		} finally {
+			disposeVirtualFs(vfsId);
+		}
+	} finally {
+		setFilesystemLockTestHookForTests();
+		globalThis.fetch = originalFetch;
+	}
+};
+
+const main = async () => {
+	const configPath = process.argv[2];
+	if (!configPath) {
+		throw new Error('Expected worker config path argument');
+	}
+
+	const configText = await Bun.file(configPath).text();
+	const config = JSON.parse(configText) as WorkerConfig;
+	if (config.mock.stdout) process.stdout.write(config.mock.stdout);
+	if (config.mock.stderr) process.stderr.write(config.mock.stderr);
+	const result = await run(config);
+	if (config.mock.exitBeforeResult) {
+		process.exit(config.mock.exitCode ?? 1);
+	}
+	sendWorkerMessage({
+		type: 'result',
+		result
+	});
+};
+
+if (import.meta.main) {
+	try {
+		await main();
+	} catch (cause) {
+		const message =
+			cause instanceof Error ? `${cause.message}\n${cause.stack ?? ''}` : String(cause);
+		sendWorkerMessage({
+			type: 'error',
+			message
+		});
+		console.error(message);
+		process.exit(1);
+	}
+}

--- a/apps/server/src/resources/impls/test-fixtures/process-support.ts
+++ b/apps/server/src/resources/impls/test-fixtures/process-support.ts
@@ -1,0 +1,34 @@
+export const readStream = async (stream: ReadableStream<Uint8Array> | null) => {
+	if (!stream) return '';
+	return await new Response(stream).text();
+};
+
+export const waitFor = async (predicate: () => boolean | Promise<boolean>, timeoutMs = 4_000) => {
+	const startedAt = performance.now();
+	while (performance.now() - startedAt < timeoutMs) {
+		if (await predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error('Timed out waiting for condition');
+};
+
+export const logQueueMetrics = (
+	label: string,
+	metrics: Record<string, number | readonly number[]>
+) => {
+	const roundMetricValue = (value: number | readonly number[]) => {
+		if (typeof value === 'number') {
+			return Number(value.toFixed(2));
+		}
+		return value.map((entry) => Number(entry.toFixed(2)));
+	};
+
+	console.info(
+		`[btca queue-metrics] ${JSON.stringify({
+			label,
+			...Object.fromEntries(
+				Object.entries(metrics).map(([key, value]) => [key, roundMetricValue(value)])
+			)
+		})}`
+	);
+};

--- a/apps/server/src/resources/index.ts
+++ b/apps/server/src/resources/index.ts
@@ -21,6 +21,14 @@ export {
 export {
 	FS_RESOURCE_SYSTEM_NOTE,
 	type BtcaFsResource,
+	type BtcaGitFsResource,
 	type BtcaGitResourceArgs,
+	type BtcaGitMaterializationMetadata,
+	type BtcaLocalFsResource,
+	type BtcaLocalMaterializationMetadata,
+	type BtcaNpmFsResource,
+	type BtcaNpmMaterializationMetadata,
+	type BtcaResourceMaterializationMetadata,
+	type BtcaResourceMaterializationResult,
 	type BtcaNpmResourceArgs
 } from './types.ts';

--- a/apps/server/src/resources/layout.ts
+++ b/apps/server/src/resources/layout.ts
@@ -1,0 +1,40 @@
+import path from 'node:path';
+
+export const RESOURCE_LOCKS_DIR = '.resource-locks';
+export const CLEAR_LOCK_NAME = 'clear.lock';
+export const GIT_MIRRORS_DIR = '.git-mirrors';
+export const TMP_DIR = '.tmp';
+export const CLEAR_TRASH_DIR = '.clear-trash';
+
+export const getResourceLocksRoot = (resourcesDirectory: string) =>
+	path.join(resourcesDirectory, RESOURCE_LOCKS_DIR);
+
+export const getClearLockPath = (resourcesDirectory: string) =>
+	path.join(getResourceLocksRoot(resourcesDirectory), CLEAR_LOCK_NAME);
+
+export const getGitLockPath = (resourcesDirectory: string, key: string) =>
+	path.join(getResourceLocksRoot(resourcesDirectory), `git.${key}.lock`);
+
+export const getNpmLockPath = (resourcesDirectory: string, key: string) =>
+	path.join(getResourceLocksRoot(resourcesDirectory), `npm.${key}.lock`);
+
+export const getGitMirrorRoot = (resourcesDirectory: string) =>
+	path.join(resourcesDirectory, GIT_MIRRORS_DIR);
+
+export const getGitMirrorPath = (resourcesDirectory: string, key: string) =>
+	path.join(getGitMirrorRoot(resourcesDirectory), key);
+
+export const getGitMirrorRepoPath = (resourcesDirectory: string, key: string) =>
+	path.join(getGitMirrorPath(resourcesDirectory, key), 'repo');
+
+export const getTopLevelCachePath = (resourcesDirectory: string, key: string) =>
+	path.join(resourcesDirectory, key);
+
+export const getClearTrashRoot = (resourcesDirectory: string) =>
+	path.join(resourcesDirectory, CLEAR_TRASH_DIR);
+
+export const getTmpCacheRoot = (resourcesDirectory: string) =>
+	path.join(resourcesDirectory, TMP_DIR);
+
+export const getTmpCachePath = (resourcesDirectory: string, key: string) =>
+	path.join(getTmpCacheRoot(resourcesDirectory), key);

--- a/apps/server/src/resources/lock.test.ts
+++ b/apps/server/src/resources/lock.test.ts
@@ -166,7 +166,7 @@ describe('resource lock helper', () => {
 		expect(staleAcquired).toBe(true);
 	});
 
-	it('reclaims a stale owner-without-heartbeat lock even if the pid is currently live', async () => {
+	it('reclaims a stale owner-without-heartbeat lock even if the owner pid is still live', async () => {
 		const lockPath = path.join(tempDir, 'stale-live-pid-pre-heartbeat.lock');
 		await fs.mkdir(lockPath, { recursive: true });
 		await writeOwner(lockPath, {
@@ -174,13 +174,15 @@ describe('resource lock helper', () => {
 			startedAt: new Date(Date.now() - 5_000).toISOString()
 		});
 
-		await waitForFilesystemLockToClear({
-			lockPath,
-			label: 'stale-live-pid-pre-heartbeat',
-			pollMs: 10,
-			heartbeatMs: 20,
-			staleMs: 100
-		});
+		await expect(
+			clearFilesystemLockIfAbsentOrStale({
+				lockPath,
+				label: 'stale-live-pid-pre-heartbeat',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			})
+		).resolves.toBe(true);
 
 		const exists = await fs
 			.stat(lockPath)
@@ -189,7 +191,7 @@ describe('resource lock helper', () => {
 		expect(exists).toBe(false);
 	});
 
-	it('reclaims a stale heartbeat lock even if the pid is currently live', async () => {
+	it('reclaims a stale heartbeat lock even if the owner pid is still live', async () => {
 		const lockPath = path.join(tempDir, 'stale-live-pid-heartbeat.lock');
 		await fs.mkdir(lockPath, { recursive: true });
 		await writeOwner(lockPath, {
@@ -202,19 +204,121 @@ describe('resource lock helper', () => {
 		await fs.utimes(heartbeatPath, oldDate, oldDate);
 		await fs.utimes(lockPath, oldDate, oldDate);
 
-		await waitForFilesystemLockToClear({
-			lockPath,
-			label: 'stale-live-pid-heartbeat',
-			pollMs: 10,
-			heartbeatMs: 20,
-			staleMs: 100
-		});
+		await expect(
+			clearFilesystemLockIfAbsentOrStale({
+				lockPath,
+				label: 'stale-live-pid-heartbeat',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			})
+		).resolves.toBe(true);
 
 		const exists = await fs
 			.stat(lockPath)
 			.then(() => true)
 			.catch(() => false);
 		expect(exists).toBe(false);
+	});
+
+	it('removes the lock directory if bootstrap fails after mkdir succeeds', async () => {
+		const lockPath = path.join(tempDir, 'bootstrap-failure.lock');
+		const originalWrite = Bun.write.bind(Bun);
+		const writeSpy = jest.spyOn(Bun, 'write').mockImplementation(async (...writeArgs) => {
+			const target = writeArgs[0];
+			if (
+				typeof target === 'string' &&
+				target.endsWith(path.join('bootstrap-failure.lock', 'owner.json'))
+			) {
+				throw new Error('owner write failed');
+			}
+			return originalWrite(
+				writeArgs[0] as Parameters<typeof Bun.write>[0],
+				writeArgs[1] as Parameters<typeof Bun.write>[1],
+				writeArgs[2] as Parameters<typeof Bun.write>[2]
+			);
+		});
+
+		try {
+			await expect(
+				withFilesystemLock(
+					{
+						lockPath,
+						label: 'bootstrap-failure',
+						pollMs: 10,
+						heartbeatMs: 20,
+						staleMs: 100
+					},
+					async () => undefined
+				)
+			).rejects.toThrow('owner write failed');
+		} finally {
+			writeSpy.mockRestore();
+		}
+
+		const exists = await fs
+			.stat(lockPath)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+
+	it('continues holding the lock when a heartbeat refresh fails in the background', async () => {
+		const lockPath = path.join(tempDir, 'heartbeat-refresh-failure.lock');
+		const originalUtimes = fs.utimes.bind(fs);
+		const originalWrite = Bun.write.bind(Bun);
+		let heartbeatUtimesCalls = 0;
+		let heartbeatWriteCalls = 0;
+		const utimesSpy = jest.spyOn(fs, 'utimes').mockImplementation(async (...utimesArgs) => {
+			const target = String(utimesArgs[0]);
+			if (target.endsWith(path.join('heartbeat-refresh-failure.lock', 'heartbeat'))) {
+				heartbeatUtimesCalls += 1;
+				if (heartbeatUtimesCalls >= 2) {
+					throw new Error('heartbeat utimes failed');
+				}
+			}
+			return originalUtimes(...utimesArgs);
+		});
+		const writeSpy = jest.spyOn(Bun, 'write').mockImplementation(async (...writeArgs) => {
+			const target = writeArgs[0];
+			if (
+				typeof target === 'string' &&
+				target.endsWith(path.join('heartbeat-refresh-failure.lock', 'heartbeat'))
+			) {
+				heartbeatWriteCalls += 1;
+				if (heartbeatWriteCalls >= 2) {
+					throw new Error('heartbeat write failed');
+				}
+			}
+			return originalWrite(
+				writeArgs[0] as Parameters<typeof Bun.write>[0],
+				writeArgs[1] as Parameters<typeof Bun.write>[1],
+				writeArgs[2] as Parameters<typeof Bun.write>[2]
+			);
+		});
+
+		let completed = false;
+		try {
+			await withFilesystemLock(
+				{
+					lockPath,
+					label: 'heartbeat-refresh-failure',
+					pollMs: 10,
+					heartbeatMs: 20,
+					staleMs: 100
+				},
+				async () => {
+					await sleep(80);
+					completed = true;
+				}
+			);
+		} finally {
+			utimesSpy.mockRestore();
+			writeSpy.mockRestore();
+		}
+
+		expect(completed).toBe(true);
+		expect(heartbeatWriteCalls).toBeGreaterThanOrEqual(2);
 	});
 
 	it('reclaims a stale lock with no usable metadata', async () => {

--- a/apps/server/src/resources/lock.test.ts
+++ b/apps/server/src/resources/lock.test.ts
@@ -1,0 +1,591 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import {
+	clearFilesystemLockIfAbsentOrStale,
+	parseActiveResourceLockDirectoryName,
+	setFilesystemLockTestHookForTests,
+	waitForFilesystemLockToClear,
+	withClearAwareFilesystemLock,
+	withFilesystemLock
+} from './lock.ts';
+
+const writeOwner = async (lockPath: string, args: { pid: number; startedAt: string }) => {
+	await Bun.write(
+		path.join(lockPath, 'owner.json'),
+		JSON.stringify(
+			{
+				pid: args.pid,
+				token: `token-${args.pid}`,
+				label: 'test-lock',
+				startedAt: args.startedAt
+			},
+			null,
+			2
+		)
+	);
+};
+
+const waitFor = async (predicate: () => boolean | Promise<boolean>, timeoutMs = 2000) => {
+	const startedAt = performance.now();
+	while (performance.now() - startedAt < timeoutMs) {
+		if (await predicate()) return;
+		await sleep(10);
+	}
+	throw new Error('Timed out waiting for condition');
+};
+
+const createDeferred = <T = void>() => {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((innerResolve) => {
+		resolve = innerResolve;
+	});
+	return { promise, resolve };
+};
+
+describe('resource lock helper', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-lock-test-'));
+	});
+
+	afterEach(async () => {
+		setFilesystemLockTestHookForTests();
+		jest.useRealTimers();
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it('parses active resource lock directory names without dot splitting', () => {
+		expect(parseActiveResourceLockDirectoryName('git.docs.v1.lock')).toEqual({
+			namespace: 'git',
+			key: 'docs.v1'
+		});
+		expect(parseActiveResourceLockDirectoryName('npm.%40scope%2Fpkg.lock')).toEqual({
+			namespace: 'npm',
+			key: '%40scope%2Fpkg'
+		});
+		expect(parseActiveResourceLockDirectoryName('npm..lock')).toBeNull();
+		expect(parseActiveResourceLockDirectoryName('npm....lock')).toBeNull();
+		expect(parseActiveResourceLockDirectoryName('git.foo bar.lock')).toBeNull();
+		expect(parseActiveResourceLockDirectoryName('clear.lock')).toBeNull();
+	});
+
+	it('does not steal a fresh lock with a missing owner file when heartbeat is fresh', async () => {
+		const lockPath = path.join(tempDir, 'git.docs.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		await Bun.write(path.join(lockPath, 'heartbeat'), '');
+
+		let acquired = false;
+		const contender = withFilesystemLock(
+			{
+				lockPath,
+				label: 'fresh-heartbeat',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				acquired = true;
+			}
+		);
+
+		let sawWaitOnFreshLock = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (event.phase === 'waiting-on-live-lock' && event.lockPath === lockPath) {
+				sawWaitOnFreshLock = true;
+			}
+		});
+
+		await waitFor(() => sawWaitOnFreshLock);
+		expect(acquired).toBe(false);
+		await fs.rm(lockPath, { recursive: true, force: true });
+		await contender;
+		expect(acquired).toBe(true);
+	});
+
+	it('treats owner-without-heartbeat as live while fresh and recoverable when stale with a dead pid', async () => {
+		const freshLockPath = path.join(tempDir, 'fresh-pre-heartbeat.lock');
+		await fs.mkdir(freshLockPath, { recursive: true });
+		await writeOwner(freshLockPath, {
+			pid: process.pid,
+			startedAt: new Date().toISOString()
+		});
+
+		let freshAcquired = false;
+		const freshContender = withFilesystemLock(
+			{
+				lockPath: freshLockPath,
+				label: 'fresh-pre-heartbeat',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				freshAcquired = true;
+			}
+		);
+
+		let sawFreshWait = false;
+		setFilesystemLockTestHookForTests((event) => {
+			if (event.phase === 'waiting-on-live-lock' && event.lockPath === freshLockPath) {
+				sawFreshWait = true;
+			}
+		});
+
+		await waitFor(() => sawFreshWait);
+		expect(freshAcquired).toBe(false);
+		await fs.rm(freshLockPath, { recursive: true, force: true });
+		await freshContender;
+		expect(freshAcquired).toBe(true);
+
+		const staleLockPath = path.join(tempDir, 'stale-pre-heartbeat.lock');
+		await fs.mkdir(staleLockPath, { recursive: true });
+		const staleStartedAt = new Date(Date.now() - 5_000).toISOString();
+		await writeOwner(staleLockPath, {
+			pid: 999999,
+			startedAt: staleStartedAt
+		});
+
+		let staleAcquired = false;
+		await withFilesystemLock(
+			{
+				lockPath: staleLockPath,
+				label: 'stale-pre-heartbeat',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				staleAcquired = true;
+			}
+		);
+		expect(staleAcquired).toBe(true);
+	});
+
+	it('reclaims a stale owner-without-heartbeat lock even if the pid is currently live', async () => {
+		const lockPath = path.join(tempDir, 'stale-live-pid-pre-heartbeat.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		await writeOwner(lockPath, {
+			pid: process.pid,
+			startedAt: new Date(Date.now() - 5_000).toISOString()
+		});
+
+		await waitForFilesystemLockToClear({
+			lockPath,
+			label: 'stale-live-pid-pre-heartbeat',
+			pollMs: 10,
+			heartbeatMs: 20,
+			staleMs: 100
+		});
+
+		const exists = await fs
+			.stat(lockPath)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+
+	it('reclaims a stale heartbeat lock even if the pid is currently live', async () => {
+		const lockPath = path.join(tempDir, 'stale-live-pid-heartbeat.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		await writeOwner(lockPath, {
+			pid: process.pid,
+			startedAt: new Date().toISOString()
+		});
+		const heartbeatPath = path.join(lockPath, 'heartbeat');
+		await Bun.write(heartbeatPath, '');
+		const oldDate = new Date(Date.now() - 5_000);
+		await fs.utimes(heartbeatPath, oldDate, oldDate);
+		await fs.utimes(lockPath, oldDate, oldDate);
+
+		await waitForFilesystemLockToClear({
+			lockPath,
+			label: 'stale-live-pid-heartbeat',
+			pollMs: 10,
+			heartbeatMs: 20,
+			staleMs: 100
+		});
+
+		const exists = await fs
+			.stat(lockPath)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+
+	it('reclaims a stale lock with no usable metadata', async () => {
+		const lockPath = path.join(tempDir, 'damaged.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		const oldDate = new Date(Date.now() - 5_000);
+		await fs.utimes(lockPath, oldDate, oldDate);
+
+		let acquired = false;
+		await withFilesystemLock(
+			{
+				lockPath,
+				label: 'damaged-lock',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				acquired = true;
+			}
+		);
+		expect(acquired).toBe(true);
+	});
+
+	it('does not delete a fresh lock that replaced a stale one during stale-break handling', async () => {
+		const lockPath = path.join(tempDir, 'aba.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		const oldDate = new Date(Date.now() - 5_000);
+		await fs.utimes(lockPath, oldDate, oldDate);
+
+		let swapped = false;
+		setFilesystemLockTestHookForTests(async (event) => {
+			if (
+				!swapped &&
+				event.phase === 'stale-break-after-claim-mkdir' &&
+				event.lockPath === lockPath
+			) {
+				swapped = true;
+				await fs.rm(lockPath, { recursive: true, force: true });
+				await fs.mkdir(lockPath, { recursive: true });
+				await writeOwner(lockPath, {
+					pid: process.pid,
+					startedAt: new Date().toISOString()
+				});
+				await Bun.write(path.join(lockPath, 'heartbeat'), '');
+			}
+		});
+
+		let acquired = false;
+		const contender = withFilesystemLock(
+			{
+				lockPath,
+				label: 'aba-contender',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				acquired = true;
+			}
+		);
+
+		try {
+			await waitFor(() => swapped);
+			expect(swapped).toBe(true);
+			expect(acquired).toBe(false);
+			const freshLockStillExists = await fs
+				.stat(lockPath)
+				.then(() => true)
+				.catch(() => false);
+			expect(freshLockStillExists).toBe(true);
+
+			await fs.rm(lockPath, { recursive: true, force: true });
+			await contender;
+			expect(acquired).toBe(true);
+		} finally {
+			setFilesystemLockTestHookForTests();
+		}
+	});
+
+	it('retries cleanly if a stale lock disappears before the stale-break claim mkdir runs', async () => {
+		const lockPath = path.join(tempDir, 'claim-parent-vanishes.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		const oldDate = new Date(Date.now() - 5_000);
+		await fs.utimes(lockPath, oldDate, oldDate);
+
+		let removedBeforeClaim = false;
+		setFilesystemLockTestHookForTests(async (event) => {
+			if (
+				!removedBeforeClaim &&
+				event.phase === 'stale-break-before-claim-mkdir' &&
+				event.lockPath === lockPath
+			) {
+				removedBeforeClaim = true;
+				await fs.rm(lockPath, { recursive: true, force: true });
+			}
+		});
+
+		let acquired = false;
+		try {
+			await withFilesystemLock(
+				{
+					lockPath,
+					label: 'claim-parent-vanishes',
+					pollMs: 10,
+					heartbeatMs: 20,
+					staleMs: 100
+				},
+				async () => {
+					acquired = true;
+				}
+			);
+		} finally {
+			setFilesystemLockTestHookForTests();
+		}
+
+		expect(removedBeforeClaim).toBe(true);
+		expect(acquired).toBe(true);
+	});
+
+	it('keeps a fresh winner lock intact when two contenders race on the same stale lock', async () => {
+		const lockPath = path.join(tempDir, 'two-contenders.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		const oldDate = new Date(Date.now() - 5_000);
+		await fs.utimes(lockPath, oldDate, oldDate);
+
+		let claimCreated = false;
+		let releaseClaimCreation: () => void = () => {};
+		const allowClaimCreationToContinue = new Promise<void>((resolve) => {
+			releaseClaimCreation = resolve;
+		});
+
+		setFilesystemLockTestHookForTests(async (event) => {
+			if (
+				!claimCreated &&
+				event.phase === 'stale-break-after-claim-mkdir' &&
+				event.lockPath === lockPath
+			) {
+				claimCreated = true;
+				await allowClaimCreationToContinue;
+			}
+		});
+
+		let firstAcquired = false;
+		let secondAcquired = false;
+		let releaseFirst: () => void = () => {};
+		const firstMayFinish = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const first = withFilesystemLock(
+			{
+				lockPath,
+				label: 'first-contender',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				firstAcquired = true;
+				await firstMayFinish;
+			}
+		);
+
+		try {
+			await waitFor(() => claimCreated);
+			const second = withFilesystemLock(
+				{
+					lockPath,
+					label: 'second-contender',
+					pollMs: 10,
+					heartbeatMs: 20,
+					staleMs: 100
+				},
+				async () => {
+					secondAcquired = true;
+				}
+			);
+
+			releaseClaimCreation();
+			await waitFor(() => firstAcquired);
+
+			expect(secondAcquired).toBe(false);
+			const freshLockStillExists = await fs
+				.stat(lockPath)
+				.then(() => true)
+				.catch(() => false);
+			expect(freshLockStillExists).toBe(true);
+
+			releaseFirst();
+			await first;
+			await second;
+			expect(secondAcquired).toBe(true);
+		} finally {
+			releaseFirst();
+			releaseClaimCreation();
+			setFilesystemLockTestHookForTests();
+		}
+	});
+
+	it('clears stale locks while passively waiting for them to disappear', async () => {
+		const lockPath = path.join(tempDir, 'wait-clear.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		const oldDate = new Date(Date.now() - 5_000);
+		await fs.utimes(lockPath, oldDate, oldDate);
+
+		await waitForFilesystemLockToClear({
+			lockPath,
+			label: 'wait-clear',
+			pollMs: 10,
+			heartbeatMs: 20,
+			staleMs: 100
+		});
+
+		const exists = await fs
+			.stat(lockPath)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+
+	it('returns true when clearFilesystemLockIfAbsentOrStale sees no lock', async () => {
+		const lockPath = path.join(tempDir, 'absent.lock');
+
+		await expect(
+			clearFilesystemLockIfAbsentOrStale({
+				lockPath,
+				label: 'absent-lock',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			})
+		).resolves.toBe(true);
+	});
+
+	it('returns false when clearFilesystemLockIfAbsentOrStale sees a fresh live lock', async () => {
+		const lockPath = path.join(tempDir, 'live.lock');
+		const holderReady = createDeferred();
+		const releaseHolder = createDeferred();
+
+		const holder = withFilesystemLock(
+			{
+				lockPath,
+				label: 'live-lock',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			},
+			async () => {
+				holderReady.resolve();
+				await releaseHolder.promise;
+			}
+		);
+
+		try {
+			await holderReady.promise;
+			await expect(
+				clearFilesystemLockIfAbsentOrStale({
+					lockPath,
+					label: 'live-lock-clear',
+					pollMs: 10,
+					heartbeatMs: 20,
+					staleMs: 100
+				})
+			).resolves.toBe(false);
+		} finally {
+			releaseHolder.resolve();
+			await holder;
+		}
+	});
+
+	it('reclaims a stale lock when clearFilesystemLockIfAbsentOrStale is called directly', async () => {
+		const lockPath = path.join(tempDir, 'stale-clear.lock');
+		await fs.mkdir(lockPath, { recursive: true });
+		await writeOwner(lockPath, {
+			pid: 999999,
+			startedAt: new Date(Date.now() - 5_000).toISOString()
+		});
+
+		await expect(
+			clearFilesystemLockIfAbsentOrStale({
+				lockPath,
+				label: 'stale-clear',
+				pollMs: 10,
+				heartbeatMs: 20,
+				staleMs: 100
+			})
+		).resolves.toBe(true);
+
+		const exists = await fs
+			.stat(lockPath)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+
+	it('retries clear-aware locking once and executes the callback only after the clear lock is gone', async () => {
+		jest.useFakeTimers();
+
+		const clearLockPath = path.join(tempDir, 'clear.lock');
+		const resourceLockPath = path.join(tempDir, 'git.docs.lock');
+		const acquiredAfterWait = createDeferred();
+		const retryObserved = createDeferred();
+		let resourceLockAcquireCount = 0;
+		let clearLockInjected = false;
+		let callbackCount = 0;
+
+		setFilesystemLockTestHookForTests(async (event) => {
+			if (
+				event.phase === 'clear-aware-resource-lock-acquired' &&
+				event.resourceLockPath === resourceLockPath
+			) {
+				resourceLockAcquireCount += 1;
+				if (!clearLockInjected) {
+					clearLockInjected = true;
+					await fs.mkdir(clearLockPath, { recursive: true });
+					await Bun.write(
+						path.join(clearLockPath, 'owner.json'),
+						JSON.stringify(
+							{
+								pid: process.pid,
+								token: 'clear-lock-test',
+								label: 'clear-lock-test',
+								startedAt: new Date().toISOString()
+							},
+							null,
+							2
+						)
+					);
+					await Bun.write(path.join(clearLockPath, 'heartbeat'), '');
+				} else {
+					acquiredAfterWait.resolve();
+				}
+			}
+
+			if (
+				event.phase === 'clear-aware-retry-after-clear' &&
+				event.resourceLockPath === resourceLockPath
+			) {
+				retryObserved.resolve();
+			}
+		});
+
+		try {
+			const resultPromise = withClearAwareFilesystemLock(
+				{
+					clearLockPath,
+					clearLockWaitLabel: 'wait-clear-before-git.docs',
+					clearLockInspectLabel: 'inspect-clear-before-git.docs',
+					resourceLockPath,
+					resourceLockLabel: 'git.docs',
+					quiet: true
+				},
+				async () => {
+					callbackCount += 1;
+					return 'done';
+				}
+			);
+
+			await retryObserved.promise;
+			expect(callbackCount).toBe(0);
+
+			await fs.rm(clearLockPath, { recursive: true, force: true });
+			jest.advanceTimersByTime(120);
+			await acquiredAfterWait.promise;
+
+			await expect(resultPromise).resolves.toBe('done');
+			expect(resourceLockAcquireCount).toBe(2);
+			expect(callbackCount).toBe(1);
+		} finally {
+			setFilesystemLockTestHookForTests();
+			jest.useRealTimers();
+		}
+	});
+});

--- a/apps/server/src/resources/lock.ts
+++ b/apps/server/src/resources/lock.ts
@@ -1,0 +1,568 @@
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+export type FilesystemLockArgs = {
+	readonly lockPath: string;
+	readonly label: string;
+	readonly pollMs?: number;
+	readonly heartbeatMs?: number;
+	readonly staleMs?: number;
+	readonly quiet?: boolean;
+};
+
+export type ClearAwareFilesystemLockArgs = {
+	readonly clearLockPath: string;
+	readonly clearLockWaitLabel: string;
+	readonly clearLockInspectLabel: string;
+	readonly resourceLockPath: string;
+	readonly resourceLockLabel: string;
+	readonly quiet?: boolean;
+};
+
+export type FilesystemLockOwner = {
+	readonly pid: number;
+	readonly token: string;
+	readonly label: string;
+	readonly startedAt: string;
+};
+
+type ResolvedFilesystemLockArgs = Required<FilesystemLockArgs>;
+
+type LockInstanceIdentity = {
+	readonly dev: string;
+	readonly ino: string;
+	readonly mtimeMs: number;
+};
+
+type FreshnessSource = 'heartbeat' | 'startedAt' | 'lockMtime';
+
+type LockObservation = {
+	readonly status: 'absent' | 'live' | 'stale';
+	readonly instance?: LockInstanceIdentity;
+	readonly owner: FilesystemLockOwner | null;
+	readonly freshnessSource?: FreshnessSource;
+	readonly freshnessTimestampMs?: number;
+};
+
+type StaleBreakClaim = {
+	readonly token: string;
+	readonly claimedAt: string;
+	readonly observedDev: string;
+	readonly observedIno: string;
+	readonly freshnessSource: FreshnessSource;
+	readonly observedLockMtimeMs?: string;
+};
+
+export type FilesystemLockTestEvent =
+	| {
+			readonly phase: 'stale-break-before-claim-mkdir' | 'stale-break-after-claim-mkdir';
+			readonly lockPath: string;
+			readonly claimPath: string;
+	  }
+	| {
+			readonly phase: 'waiting-on-live-lock';
+			readonly lockPath: string;
+			readonly label: string;
+	  }
+	| {
+			readonly phase: 'clear-wait-started' | 'clear-wait-finished';
+			readonly lockPath: string;
+			readonly label: string;
+	  }
+	| {
+			readonly phase: 'clear-aware-resource-lock-acquired' | 'clear-aware-retry-after-clear';
+			readonly clearLockPath: string;
+			readonly clearLockWaitLabel: string;
+			readonly clearLockInspectLabel: string;
+			readonly resourceLockPath: string;
+			readonly resourceLockLabel: string;
+	  };
+
+const OWNER_FILE = 'owner.json';
+const HEARTBEAT_FILE = 'heartbeat';
+const STALE_BREAK_CLAIM_DIR = '.stale-break-claim';
+const STALE_BREAK_CLAIM_FILE = 'claim.json';
+
+let filesystemLockTestHookForTests:
+	| ((event: FilesystemLockTestEvent) => void | Promise<void>)
+	| undefined;
+
+export const DEFAULT_LOCK_POLL_MS = 100;
+export const DEFAULT_LOCK_HEARTBEAT_MS = 2000;
+export const DEFAULT_LOCK_STALE_MS = 30000;
+
+export const setFilesystemLockTestHookForTests = (
+	hook?: (event: FilesystemLockTestEvent) => void | Promise<void>
+) => {
+	filesystemLockTestHookForTests = hook;
+};
+
+const emitFilesystemLockTestEvent = async (event: FilesystemLockTestEvent) => {
+	await filesystemLockTestHookForTests?.(event);
+};
+
+const resolveLockArgs = (args: FilesystemLockArgs): ResolvedFilesystemLockArgs => {
+	const resolved = {
+		lockPath: args.lockPath,
+		label: args.label,
+		pollMs: args.pollMs ?? DEFAULT_LOCK_POLL_MS,
+		heartbeatMs: args.heartbeatMs ?? DEFAULT_LOCK_HEARTBEAT_MS,
+		staleMs: args.staleMs ?? DEFAULT_LOCK_STALE_MS,
+		quiet: args.quiet ?? false
+	};
+
+	if (resolved.staleMs < resolved.heartbeatMs * 5) {
+		throw new Error(
+			`Invalid filesystem lock timings for "${resolved.label}": staleMs must be at least heartbeatMs * 5`
+		);
+	}
+
+	return resolved;
+};
+
+const ensureLockParent = async (lockPath: string) => {
+	await fs.mkdir(path.dirname(lockPath), { recursive: true });
+};
+
+const getHeartbeatPath = (lockPath: string) => path.join(lockPath, HEARTBEAT_FILE);
+const getOwnerPath = (lockPath: string) => path.join(lockPath, OWNER_FILE);
+const getClaimPath = (lockPath: string) => path.join(lockPath, STALE_BREAK_CLAIM_DIR);
+const getClaimFilePath = (lockPath: string) =>
+	path.join(getClaimPath(lockPath), STALE_BREAK_CLAIM_FILE);
+
+const readJsonFile = async <T>(filePath: string): Promise<T | null> => {
+	try {
+		return JSON.parse(await Bun.file(filePath).text()) as T;
+	} catch {
+		return null;
+	}
+};
+
+const safeStat = async (filePath: string) => {
+	try {
+		return await fs.stat(filePath);
+	} catch {
+		return null;
+	}
+};
+
+const readLockInstanceIdentity = async (lockPath: string): Promise<LockInstanceIdentity | null> => {
+	try {
+		const stats = await fs.lstat(lockPath, { bigint: true });
+		return {
+			dev: stats.dev.toString(),
+			ino: stats.ino.toString(),
+			mtimeMs: Number(stats.mtimeMs)
+		};
+	} catch {
+		return null;
+	}
+};
+
+const sameInstance = (
+	left?: Pick<LockInstanceIdentity, 'dev' | 'ino'> | null,
+	right?: Pick<LockInstanceIdentity, 'dev' | 'ino'> | null
+) => Boolean(left && right && left.dev === right.dev && left.ino === right.ino);
+
+const isValidActiveResourceLockKey = (key: string) => {
+	if (key.length === 0 || key === '.' || key === '..') return false;
+
+	try {
+		return encodeURIComponent(decodeURIComponent(key)) === key;
+	} catch {
+		return false;
+	}
+};
+
+export const readLockOwner = async (lockPath: string): Promise<FilesystemLockOwner | null> => {
+	const parsed = await readJsonFile<Partial<FilesystemLockOwner>>(getOwnerPath(lockPath));
+	if (
+		typeof parsed?.pid === 'number' &&
+		typeof parsed.token === 'string' &&
+		typeof parsed.label === 'string' &&
+		typeof parsed.startedAt === 'string'
+	) {
+		return {
+			pid: parsed.pid,
+			token: parsed.token,
+			label: parsed.label,
+			startedAt: parsed.startedAt
+		};
+	}
+	return null;
+};
+
+const readClaim = async (lockPath: string): Promise<StaleBreakClaim | null> => {
+	const parsed = await readJsonFile<Partial<StaleBreakClaim>>(getClaimFilePath(lockPath));
+	if (
+		typeof parsed?.token === 'string' &&
+		typeof parsed.claimedAt === 'string' &&
+		typeof parsed.observedDev === 'string' &&
+		typeof parsed.observedIno === 'string' &&
+		(parsed.freshnessSource === 'heartbeat' ||
+			parsed.freshnessSource === 'startedAt' ||
+			parsed.freshnessSource === 'lockMtime')
+	) {
+		return {
+			token: parsed.token,
+			claimedAt: parsed.claimedAt,
+			observedDev: parsed.observedDev,
+			observedIno: parsed.observedIno,
+			freshnessSource: parsed.freshnessSource,
+			...(typeof parsed.observedLockMtimeMs === 'string'
+				? { observedLockMtimeMs: parsed.observedLockMtimeMs }
+				: {})
+		};
+	}
+	return null;
+};
+
+const touchHeartbeat = async (lockPath: string) => {
+	const heartbeatPath = getHeartbeatPath(lockPath);
+	const now = new Date();
+	try {
+		await fs.utimes(heartbeatPath, now, now);
+	} catch {
+		await Bun.write(heartbeatPath, '');
+	}
+};
+
+const observeLock = async (
+	args: ResolvedFilesystemLockArgs,
+	options?: { readonly fallbackLockMtimeMs?: number }
+): Promise<LockObservation> => {
+	const instance = await readLockInstanceIdentity(args.lockPath);
+	if (!instance) {
+		return { status: 'absent', owner: null };
+	}
+
+	const owner = await readLockOwner(args.lockPath);
+	const heartbeat = await safeStat(getHeartbeatPath(args.lockPath));
+	const now = Date.now();
+
+	if (heartbeat) {
+		if (now - heartbeat.mtimeMs < args.staleMs) {
+			return {
+				status: 'live',
+				instance,
+				owner,
+				freshnessSource: 'heartbeat',
+				freshnessTimestampMs: heartbeat.mtimeMs
+			};
+		}
+
+		return {
+			status: 'stale',
+			instance,
+			owner,
+			freshnessSource: 'heartbeat',
+			freshnessTimestampMs: heartbeat.mtimeMs
+		};
+	}
+
+	if (owner) {
+		const startedAtMs = Date.parse(owner.startedAt);
+		const freshnessTimestampMs = Number.isFinite(startedAtMs)
+			? startedAtMs
+			: (options?.fallbackLockMtimeMs ?? instance.mtimeMs);
+
+		if (now - freshnessTimestampMs < args.staleMs) {
+			return {
+				status: 'live',
+				instance,
+				owner,
+				freshnessSource: Number.isFinite(startedAtMs) ? 'startedAt' : 'lockMtime',
+				freshnessTimestampMs
+			};
+		}
+
+		return {
+			status: 'stale',
+			instance,
+			owner,
+			freshnessSource: Number.isFinite(startedAtMs) ? 'startedAt' : 'lockMtime',
+			freshnessTimestampMs
+		};
+	}
+
+	const freshnessTimestampMs = options?.fallbackLockMtimeMs ?? instance.mtimeMs;
+	return {
+		status: now - freshnessTimestampMs < args.staleMs ? 'live' : 'stale',
+		instance,
+		owner: null,
+		freshnessSource: 'lockMtime',
+		freshnessTimestampMs
+	};
+};
+
+const tryClearStaleClaim = async (args: ResolvedFilesystemLockArgs) => {
+	const claimPath = getClaimPath(args.lockPath);
+	const claim = await readClaim(args.lockPath);
+	const stat = await safeStat(claimPath);
+	if (!stat) return false;
+
+	const claimedAtMs = claim ? Date.parse(claim.claimedAt) : Number.NaN;
+	const freshnessTimestampMs = Number.isFinite(claimedAtMs) ? claimedAtMs : stat.mtimeMs;
+	if (Date.now() - freshnessTimestampMs < args.staleMs) return false;
+
+	await fs.rm(claimPath, { recursive: true, force: true });
+	return true;
+};
+
+const releaseClaimIfOwned = async (args: ResolvedFilesystemLockArgs, token: string) => {
+	const claim = await readClaim(args.lockPath);
+	if (!claim || claim.token !== token) return;
+	await fs.rm(getClaimPath(args.lockPath), { recursive: true, force: true });
+};
+
+const tryBreakStaleLock = async (
+	args: ResolvedFilesystemLockArgs,
+	observation: LockObservation
+): Promise<boolean> => {
+	if (observation.status !== 'stale' || !observation.instance || !observation.freshnessSource) {
+		return false;
+	}
+
+	const claimPath = getClaimPath(args.lockPath);
+	const claimToken = randomUUID();
+	await emitFilesystemLockTestEvent({
+		phase: 'stale-break-before-claim-mkdir',
+		lockPath: args.lockPath,
+		claimPath
+	});
+	try {
+		await fs.mkdir(claimPath);
+	} catch (cause) {
+		const code =
+			typeof cause === 'object' && cause && 'code' in cause
+				? (cause as { code?: string }).code
+				: '';
+		if (code === 'EEXIST') {
+			return tryClearStaleClaim(args);
+		}
+		if (code === 'ENOENT') {
+			return true;
+		}
+		throw cause;
+	}
+
+	await emitFilesystemLockTestEvent({
+		phase: 'stale-break-after-claim-mkdir',
+		lockPath: args.lockPath,
+		claimPath
+	});
+
+	const claim: StaleBreakClaim = {
+		token: claimToken,
+		claimedAt: new Date().toISOString(),
+		observedDev: observation.instance.dev,
+		observedIno: observation.instance.ino,
+		freshnessSource: observation.freshnessSource,
+		...(observation.freshnessSource === 'lockMtime'
+			? {
+					observedLockMtimeMs: String(
+						observation.freshnessTimestampMs ?? observation.instance.mtimeMs
+					)
+				}
+			: {})
+	};
+
+	await Bun.write(getClaimFilePath(args.lockPath), JSON.stringify(claim, null, 2));
+
+	const currentInstance = await readLockInstanceIdentity(args.lockPath);
+	if (!sameInstance(currentInstance, observation.instance)) {
+		await releaseClaimIfOwned(args, claimToken);
+		return true;
+	}
+
+	const rechecked = await observeLock(args, {
+		fallbackLockMtimeMs:
+			observation.freshnessSource === 'lockMtime'
+				? (observation.freshnessTimestampMs ?? observation.instance.mtimeMs)
+				: undefined
+	});
+	if (rechecked.status !== 'stale' || !sameInstance(rechecked.instance, observation.instance)) {
+		await releaseClaimIfOwned(args, claimToken);
+		return false;
+	}
+
+	await fs.rm(args.lockPath, { recursive: true, force: true });
+	return true;
+};
+
+const waitUntilLockClears = async (args: ResolvedFilesystemLockArgs) => {
+	while (true) {
+		const observation = await observeLock(args);
+		if (observation.status === 'absent') return;
+		const changed = await tryBreakStaleLock(args, observation);
+		if (!changed) {
+			if (observation.status === 'live') {
+				await emitFilesystemLockTestEvent({
+					phase: 'waiting-on-live-lock',
+					lockPath: args.lockPath,
+					label: args.label
+				});
+			}
+			await sleep(args.pollMs);
+		}
+	}
+};
+
+export const clearFilesystemLockIfAbsentOrStale = async (
+	args: FilesystemLockArgs
+): Promise<boolean> => {
+	const resolved = resolveLockArgs(args);
+	await ensureLockParent(resolved.lockPath);
+
+	while (true) {
+		const observation = await observeLock(resolved);
+		if (observation.status === 'absent') return true;
+		if (observation.status === 'live') return false;
+
+		const changed = await tryBreakStaleLock(resolved, observation);
+		if (!changed) return false;
+	}
+};
+
+const releaseOwnedLock = async (lockPath: string, owner: FilesystemLockOwner) => {
+	const currentOwner = await readLockOwner(lockPath);
+	if (!currentOwner || currentOwner.token !== owner.token) return;
+	await fs.rm(lockPath, { recursive: true, force: true });
+};
+
+export const withFilesystemLock = async <T>(
+	args: FilesystemLockArgs,
+	use: () => Promise<T>
+): Promise<T> => {
+	const resolved = resolveLockArgs(args);
+	await ensureLockParent(resolved.lockPath);
+
+	while (true) {
+		try {
+			await fs.mkdir(resolved.lockPath);
+		} catch (cause) {
+			const code =
+				typeof cause === 'object' && cause && 'code' in cause
+					? (cause as { code?: string }).code
+					: '';
+			if (code === 'EEXIST') {
+				await waitUntilLockClears(resolved);
+				continue;
+			}
+			throw cause;
+		}
+
+		const owner: FilesystemLockOwner = {
+			pid: process.pid,
+			token: randomUUID(),
+			label: resolved.label,
+			startedAt: new Date().toISOString()
+		};
+		await Bun.write(getOwnerPath(resolved.lockPath), JSON.stringify(owner, null, 2));
+		await touchHeartbeat(resolved.lockPath);
+
+		const interval = setInterval(() => {
+			void touchHeartbeat(resolved.lockPath);
+		}, resolved.heartbeatMs);
+
+		try {
+			return await use();
+		} finally {
+			clearInterval(interval);
+			await releaseOwnedLock(resolved.lockPath, owner);
+		}
+	}
+};
+
+export const waitForFilesystemLockToClear = async (args: FilesystemLockArgs): Promise<void> => {
+	const resolved = resolveLockArgs(args);
+	await ensureLockParent(resolved.lockPath);
+	await waitUntilLockClears(resolved);
+};
+
+export const withClearAwareFilesystemLock = async <T>(
+	args: ClearAwareFilesystemLockArgs,
+	use: () => Promise<T>
+): Promise<T> => {
+	while (true) {
+		await emitFilesystemLockTestEvent({
+			phase: 'clear-wait-started',
+			lockPath: args.clearLockPath,
+			label: args.clearLockWaitLabel
+		});
+		await waitForFilesystemLockToClear({
+			lockPath: args.clearLockPath,
+			label: args.clearLockWaitLabel,
+			quiet: args.quiet
+		});
+		await emitFilesystemLockTestEvent({
+			phase: 'clear-wait-finished',
+			lockPath: args.clearLockPath,
+			label: args.clearLockWaitLabel
+		});
+
+		const retryAfterClear = Symbol('retry-after-clear');
+		const result = await withFilesystemLock(
+			{
+				lockPath: args.resourceLockPath,
+				label: args.resourceLockLabel,
+				quiet: args.quiet
+			},
+			async () => {
+				await emitFilesystemLockTestEvent({
+					phase: 'clear-aware-resource-lock-acquired',
+					clearLockPath: args.clearLockPath,
+					clearLockWaitLabel: args.clearLockWaitLabel,
+					clearLockInspectLabel: args.clearLockInspectLabel,
+					resourceLockPath: args.resourceLockPath,
+					resourceLockLabel: args.resourceLockLabel
+				});
+				const clearLockIsGone = await clearFilesystemLockIfAbsentOrStale({
+					lockPath: args.clearLockPath,
+					label: args.clearLockInspectLabel,
+					quiet: args.quiet
+				});
+				if (!clearLockIsGone) {
+					await emitFilesystemLockTestEvent({
+						phase: 'clear-aware-retry-after-clear',
+						clearLockPath: args.clearLockPath,
+						clearLockWaitLabel: args.clearLockWaitLabel,
+						clearLockInspectLabel: args.clearLockInspectLabel,
+						resourceLockPath: args.resourceLockPath,
+						resourceLockLabel: args.resourceLockLabel
+					});
+					return retryAfterClear;
+				}
+
+				return use();
+			}
+		);
+
+		if (result === retryAfterClear) continue;
+		return result;
+	}
+};
+
+export const parseActiveResourceLockDirectoryName = (
+	entryName: string
+): { readonly namespace: 'git' | 'npm'; readonly key: string } | null => {
+	if (entryName.startsWith('git.') && entryName.endsWith('.lock')) {
+		const key = entryName.slice('git.'.length, -'.lock'.length);
+		if (!isValidActiveResourceLockKey(key)) return null;
+		return {
+			namespace: 'git',
+			key
+		};
+	}
+	if (entryName.startsWith('npm.') && entryName.endsWith('.lock')) {
+		const key = entryName.slice('npm.'.length, -'.lock'.length);
+		if (!isValidActiveResourceLockKey(key)) return null;
+		return {
+			namespace: 'npm',
+			key
+		};
+	}
+	return null;
+};

--- a/apps/server/src/resources/lock.ts
+++ b/apps/server/src/resources/lock.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { setTimeout as sleep } from 'node:timers/promises';
+import { setInterval as heartbeatTicks, setTimeout as sleep } from 'node:timers/promises';
 
 export type FilesystemLockArgs = {
 	readonly lockPath: string;
@@ -432,6 +432,36 @@ const releaseOwnedLock = async (lockPath: string, owner: FilesystemLockOwner) =>
 	await fs.rm(lockPath, { recursive: true, force: true });
 };
 
+const startHeartbeatLoop = (lockPath: string, heartbeatMs: number) => {
+	const controller = new AbortController();
+	const completed = (async () => {
+		try {
+			for await (const _ of heartbeatTicks(heartbeatMs, undefined, {
+				signal: controller.signal
+			})) {
+				try {
+					await touchHeartbeat(lockPath);
+				} catch {}
+			}
+		} catch (cause) {
+			const name =
+				typeof cause === 'object' && cause && 'name' in cause
+					? String((cause as { name?: unknown }).name)
+					: '';
+			if (name !== 'AbortError') {
+				return;
+			}
+		}
+	})();
+
+	return {
+		stop: async () => {
+			controller.abort();
+			await completed;
+		}
+	};
+};
+
 export const withFilesystemLock = async <T>(
 	args: FilesystemLockArgs,
 	use: () => Promise<T>
@@ -460,17 +490,20 @@ export const withFilesystemLock = async <T>(
 			label: resolved.label,
 			startedAt: new Date().toISOString()
 		};
-		await Bun.write(getOwnerPath(resolved.lockPath), JSON.stringify(owner, null, 2));
-		await touchHeartbeat(resolved.lockPath);
+		try {
+			await Bun.write(getOwnerPath(resolved.lockPath), JSON.stringify(owner, null, 2));
+			await touchHeartbeat(resolved.lockPath);
+		} catch (cause) {
+			await fs.rm(resolved.lockPath, { recursive: true, force: true }).catch(() => undefined);
+			throw cause;
+		}
 
-		const interval = setInterval(() => {
-			void touchHeartbeat(resolved.lockPath);
-		}, resolved.heartbeatMs);
+		const heartbeatLoop = startHeartbeatLoop(resolved.lockPath, resolved.heartbeatMs);
 
 		try {
 			return await use();
 		} finally {
-			clearInterval(interval);
+			await heartbeatLoop.stop();
 			await releaseOwnedLock(resolved.lockPath, owner);
 		}
 	}

--- a/apps/server/src/resources/service.test.ts
+++ b/apps/server/src/resources/service.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'bun:test';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
 	createAnonymousDirectoryKey,
 	createAnonymousResource,
+	createResourcesService,
 	resolveResourceDefinition
 } from './service.ts';
 import { resourceNameToKey } from './helpers.ts';
+import { getClearTrashRoot } from './layout.ts';
 import { type ResourceDefinition } from './schema.ts';
+import { createConfigServiceMock, createStaleLockDirectory } from './test-support.ts';
 
 describe('Resources.resolveResourceDefinition', () => {
 	const configuredResource: ResourceDefinition = {
@@ -85,6 +91,259 @@ describe('Resources.resolveResourceDefinition', () => {
 		if (main) {
 			expect(main.name.startsWith('anonymous:')).toBe(true);
 			expect(main.name.length).toBeGreaterThan(19);
+		}
+	});
+});
+
+describe('Resources.clearCachesPromise', () => {
+	it('drains opposite namespaces safely when git and npm reuse the same bare key', async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-clear-test-'));
+		try {
+			const resourcesDirectory = path.join(tempDir, 'resources');
+			await fs.mkdir(path.join(resourcesDirectory, '.git-mirrors', 'foo', 'repo', '.git'), {
+				recursive: true
+			});
+			await fs.mkdir(path.join(resourcesDirectory, 'bar'), { recursive: true });
+			await fs.mkdir(path.join(resourcesDirectory, 'foo'), { recursive: true });
+			await Bun.write(path.join(resourcesDirectory, 'bar', '.btca-npm-meta.json'), '{}');
+			await Bun.write(path.join(resourcesDirectory, 'foo', '.btca-npm-meta.json'), '{}');
+			await createStaleLockDirectory(
+				path.join(resourcesDirectory, '.resource-locks', 'npm.foo.lock')
+			);
+
+			const service = createResourcesService(
+				createConfigServiceMock({
+					resourcesDirectory,
+					resources: [
+						{
+							type: 'git',
+							name: 'foo',
+							url: 'https://github.com/example/foo',
+							branch: 'main'
+						},
+						{
+							type: 'npm',
+							name: 'bar',
+							package: 'bar'
+						}
+					]
+				})
+			);
+
+			const result = await service.clearCachesPromise();
+			expect(result.cleared).toBe(3);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, '.git-mirrors', 'foo'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, 'bar'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, 'foo'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, '.resource-locks'))
+					.then((value) => value.isDirectory())
+					.catch(() => false)
+			).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('classifies passive leftovers across mirror, top-level, tmp, and unknown caches', async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-clear-leftovers-'));
+		try {
+			const resourcesDirectory = path.join(tempDir, 'resources');
+			await fs.mkdir(path.join(resourcesDirectory, '.git-mirrors', 'legacy-git', 'repo', '.git'), {
+				recursive: true
+			});
+			await fs.mkdir(path.join(resourcesDirectory, 'legacy-npm'), { recursive: true });
+			await fs.mkdir(path.join(resourcesDirectory, 'legacy-git-top', '.git'), { recursive: true });
+			await fs.mkdir(path.join(resourcesDirectory, 'legacy-unknown'), { recursive: true });
+			await fs.mkdir(path.join(resourcesDirectory, '.tmp', 'legacy-anon'), { recursive: true });
+			await Bun.write(path.join(resourcesDirectory, 'legacy-npm', '.btca-npm-meta.json'), '{}');
+			await Bun.write(
+				path.join(resourcesDirectory, '.tmp', 'legacy-anon', '.btca-npm-meta.json'),
+				'{}'
+			);
+
+			const service = createResourcesService(
+				createConfigServiceMock({
+					resourcesDirectory,
+					resources: []
+				})
+			);
+
+			const result = await service.clearCachesPromise();
+			expect(result.cleared).toBe(5);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, '.git-mirrors', 'legacy-git'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, 'legacy-npm'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, 'legacy-git-top'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, 'legacy-unknown'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(path.join(resourcesDirectory, '.tmp', 'legacy-anon'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('clears leftover anonymous git temp directories under the git namespace', async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-clear-anon-git-'));
+		try {
+			const resourcesDirectory = path.join(tempDir, 'resources');
+			const anonymousKey = createAnonymousDirectoryKey('https://example.com/repo.git');
+			const firstTmpDir = path.join(
+				resourcesDirectory,
+				'.tmp',
+				`btca-anon-git-${anonymousKey}-first`
+			);
+			const secondTmpDir = path.join(
+				resourcesDirectory,
+				'.tmp',
+				`btca-anon-git-${anonymousKey}-second`
+			);
+			await fs.mkdir(firstTmpDir, { recursive: true });
+			await fs.mkdir(secondTmpDir, { recursive: true });
+			await Bun.write(path.join(firstTmpDir, 'README.md'), 'first');
+			await Bun.write(path.join(secondTmpDir, 'README.md'), 'second');
+
+			const service = createResourcesService(
+				createConfigServiceMock({
+					resourcesDirectory,
+					resources: []
+				})
+			);
+
+			const result = await service.clearCachesPromise();
+			expect(result.cleared).toBe(2);
+			expect(
+				await fs
+					.stat(firstTmpDir)
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(secondTmpDir)
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('removes leftover clear-trash directories without treating them as legacy caches', async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-clear-trash-'));
+		try {
+			const resourcesDirectory = path.join(tempDir, 'resources');
+			const trashRoot = getClearTrashRoot(resourcesDirectory);
+			const orphanedTrashDir = path.join(trashRoot, 'legacy-trash');
+			await fs.mkdir(orphanedTrashDir, { recursive: true });
+			await Bun.write(path.join(orphanedTrashDir, 'README.md'), 'leftover');
+
+			const service = createResourcesService(
+				createConfigServiceMock({
+					resourcesDirectory,
+					resources: []
+				})
+			);
+
+			const result = await service.clearCachesPromise();
+			expect(result.cleared).toBe(0);
+			expect(
+				await fs
+					.stat(orphanedTrashDir)
+					.then(() => true)
+					.catch(() => false)
+			).toBe(false);
+			expect(
+				await fs
+					.stat(trashRoot)
+					.then((value) => value.isDirectory())
+					.catch(() => false)
+			).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('ignores malformed active lock directory names while clearing caches', async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'btca-clear-malformed-locks-'));
+		try {
+			const resourcesDirectory = path.join(tempDir, 'resources');
+			const siblingDirectory = path.join(tempDir, 'outside');
+			await fs.mkdir(resourcesDirectory, { recursive: true });
+			await fs.mkdir(siblingDirectory, { recursive: true });
+			await Bun.write(path.join(siblingDirectory, 'keep.txt'), 'keep');
+			await fs.mkdir(path.join(resourcesDirectory, '.resource-locks', 'npm..lock'), {
+				recursive: true
+			});
+			await fs.mkdir(path.join(resourcesDirectory, '.resource-locks', 'npm....lock'), {
+				recursive: true
+			});
+			await fs.mkdir(path.join(resourcesDirectory, '.resource-locks', 'git.foo bar.lock'), {
+				recursive: true
+			});
+
+			const service = createResourcesService(
+				createConfigServiceMock({
+					resourcesDirectory,
+					resources: []
+				})
+			);
+
+			const result = await service.clearCachesPromise();
+			expect(result.cleared).toBe(0);
+			expect(
+				await fs
+					.stat(resourcesDirectory)
+					.then((value) => value.isDirectory())
+					.catch(() => false)
+			).toBe(true);
+			expect(
+				await fs
+					.stat(path.join(siblingDirectory, 'keep.txt'))
+					.then(() => true)
+					.catch(() => false)
+			).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/apps/server/src/resources/service.ts
+++ b/apps/server/src/resources/service.ts
@@ -1,14 +1,37 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readdir, rename, rm } from 'node:fs/promises';
+import path from 'node:path';
 
 import { Effect } from 'effect';
 
 import type { ConfigService as ConfigServiceShape } from '../config/index.ts';
 import { parseNpmReference, validateGitUrl } from '../validation/index.ts';
 import { CommonHints } from '../errors.ts';
+import { metricsInfo } from '../metrics/index.ts';
 
+import { directoryExists, pathExists } from './fs-utils.ts';
 import { ResourceError, resourceNameToKey } from './helpers.ts';
-import { loadGitResource } from './impls/git.ts';
-import { loadNpmResource } from './impls/npm.ts';
+import { loadGitResource, type GitResourceDeps } from './impls/git.ts';
+import { loadLocalResource } from './impls/local.ts';
+import { loadNpmResource, type NpmResourceDeps } from './impls/npm.ts';
+import {
+	CLEAR_LOCK_NAME,
+	CLEAR_TRASH_DIR,
+	GIT_MIRRORS_DIR,
+	RESOURCE_LOCKS_DIR,
+	TMP_DIR,
+	getClearLockPath,
+	getClearTrashRoot,
+	getGitLockPath,
+	getGitMirrorPath,
+	getGitMirrorRoot,
+	getNpmLockPath,
+	getResourceLocksRoot,
+	getTmpCachePath,
+	getTmpCacheRoot,
+	getTopLevelCachePath
+} from './layout.ts';
+import { parseActiveResourceLockDirectoryName, withFilesystemLock } from './lock.ts';
 import {
 	isGitResource,
 	isNpmResource,
@@ -26,8 +49,11 @@ import type {
 
 const ANON_PREFIX = 'anonymous:';
 const ANON_DIRECTORY_PREFIX = 'anonymous-';
+const ANONYMOUS_GIT_TMP_DIR_PREFIX = 'btca-anon-git-';
+const ANONYMOUS_DIRECTORY_KEY_HASH = /^[0-9a-f]{12}$/u;
 const DEFAULT_ANON_BRANCH = 'main';
-
+const CLEAR_DELETE_MAX_RETRIES = 5;
+const CLEAR_DELETE_RETRY_DELAY_MS = 100;
 export const createAnonymousDirectoryKey = (reference: string): string => {
 	const hash = createHash('sha256').update(reference).digest('hex').slice(0, 12);
 	return `${ANON_DIRECTORY_PREFIX}${hash}`;
@@ -48,6 +74,13 @@ export type ResourcesService = {
 			quiet?: boolean;
 		}
 	) => Promise<BtcaFsResource>;
+	clearCaches: () => Effect.Effect<{ cleared: number }, unknown, never>;
+	clearCachesPromise: () => Promise<{ cleared: number }>;
+};
+
+type ResourcesServiceDeps = {
+	readonly git?: Partial<GitResourceDeps>;
+	readonly npm?: Partial<NpmResourceDeps>;
 };
 
 const normalizeSearchPaths = (definition: GitResource): string[] => {
@@ -86,7 +119,8 @@ const definitionToLocalArgs = (definition: LocalResource): BtcaLocalResourceArgs
 
 const definitionToNpmArgs = (
 	definition: NpmResource,
-	resourcesDirectory: string
+	resourcesDirectory: string,
+	quiet: boolean
 ): BtcaNpmResourceArgs => {
 	const reference = `${definition.package}${definition.version ? `@${definition.version}` : ''}`;
 	return {
@@ -96,22 +130,13 @@ const definitionToNpmArgs = (
 		...(definition.version ? { version: definition.version } : {}),
 		resourcesDirectoryPath: resourcesDirectory,
 		specialAgentInstructions: definition.specialNotes ?? '',
+		quiet,
 		ephemeral: isAnonymousResource(definition.name),
 		localDirectoryKey: isAnonymousResource(definition.name)
 			? createAnonymousDirectoryKey(reference)
 			: undefined
 	};
 };
-
-const loadLocalResource = (args: BtcaLocalResourceArgs): BtcaFsResource => ({
-	_tag: 'fs-based',
-	name: args.name,
-	fsName: resourceNameToKey(args.name),
-	type: 'local',
-	repoSubPaths: [],
-	specialAgentInstructions: args.specialAgentInstructions,
-	getAbsoluteDirectoryPath: async () => args.path
-});
 
 export const createAnonymousResource = (reference: string): ResourceDefinition | null => {
 	const npmReference = parseNpmReference(reference);
@@ -153,7 +178,318 @@ export const resolveResourceDefinition = (
 	});
 };
 
-export const createResourcesService = (config: ConfigServiceShape): ResourcesService => {
+const removeDirectoryWithRetries = async (targetPath: string) => {
+	await rm(targetPath, {
+		recursive: true,
+		force: true,
+		maxRetries: CLEAR_DELETE_MAX_RETRIES,
+		retryDelay: CLEAR_DELETE_RETRY_DELAY_MS
+	});
+};
+
+const moveDirectoryToClearTrashIfExists = async (
+	resourcesDirectory: string,
+	targetPath: string
+) => {
+	if (!(await pathExists(targetPath))) return null;
+
+	const trashRoot = getClearTrashRoot(resourcesDirectory);
+	await mkdir(trashRoot, { recursive: true });
+	const trashPath = path.join(
+		trashRoot,
+		`${path.basename(targetPath)}-${Date.now()}-${randomUUID()}`
+	);
+
+	try {
+		await rename(targetPath, trashPath);
+		return trashPath;
+	} catch (cause) {
+		const code =
+			typeof cause === 'object' && cause && 'code' in cause
+				? (cause as { code?: string }).code
+				: '';
+		if (code === 'ENOENT') return null;
+		throw cause;
+	}
+};
+
+const removeClearedTrashPaths = async (trashPaths: readonly string[]) => {
+	for (const trashPath of trashPaths) {
+		await removeDirectoryWithRetries(trashPath);
+	}
+	return trashPaths.length;
+};
+
+const listDirectoryEntriesSorted = async (directoryPath: string) => {
+	try {
+		return (await readdir(directoryPath)).sort((left, right) => left.localeCompare(right));
+	} catch {
+		return [];
+	}
+};
+
+const getCurrentNamedGitKeys = (resources: readonly ResourceDefinition[]) =>
+	resources
+		.filter((resource): resource is GitResource => isGitResource(resource))
+		.map((resource) => resourceNameToKey(resource.name))
+		.sort((left, right) => left.localeCompare(right));
+
+const getCurrentNamedNpmKeys = (resources: readonly ResourceDefinition[]) =>
+	resources
+		.filter((resource): resource is NpmResource => isNpmResource(resource))
+		.map((resource) => resourceNameToKey(resource.name))
+		.sort((left, right) => left.localeCompare(right));
+
+const getExtraActiveLockKeys = async (
+	resourcesDirectory: string,
+	currentKeys: {
+		currentNamedGitKeys: readonly string[];
+		currentNamedNpmKeys: readonly string[];
+	}
+) => {
+	const lockEntries = await listDirectoryEntriesSorted(getResourceLocksRoot(resourcesDirectory));
+	const extraGitKeys = new Set<string>();
+	const extraNpmKeys = new Set<string>();
+	const currentGit = new Set(currentKeys.currentNamedGitKeys);
+	const currentNpm = new Set(currentKeys.currentNamedNpmKeys);
+
+	for (const entry of lockEntries) {
+		if (entry === CLEAR_LOCK_NAME) continue;
+		const parsed = parseActiveResourceLockDirectoryName(entry);
+		if (!parsed) continue;
+		if (parsed.namespace === 'git') {
+			if (!currentGit.has(parsed.key)) extraGitKeys.add(parsed.key);
+			continue;
+		}
+		if (!currentNpm.has(parsed.key)) extraNpmKeys.add(parsed.key);
+	}
+
+	return {
+		extraGitKeys: [...extraGitKeys].sort((left, right) => left.localeCompare(right)),
+		extraNpmKeys: [...extraNpmKeys].sort((left, right) => left.localeCompare(right))
+	};
+};
+
+const withGitDrain = async <T>(resourcesDirectory: string, key: string, drain: () => Promise<T>) =>
+	withFilesystemLock(
+		{
+			lockPath: getGitLockPath(resourcesDirectory, key),
+			label: `clear.git.${key}`,
+			quiet: true
+		},
+		drain
+	);
+
+const parseAnonymousGitTmpDirectoryKey = (entry: string) => {
+	const prefix = `${ANONYMOUS_GIT_TMP_DIR_PREFIX}${ANON_DIRECTORY_PREFIX}`;
+	if (!entry.startsWith(prefix)) return null;
+
+	const remainder = entry.slice(prefix.length);
+	const separatorIndex = remainder.indexOf('-');
+	if (separatorIndex <= 0) return null;
+
+	const hash = remainder.slice(0, separatorIndex);
+	if (!ANONYMOUS_DIRECTORY_KEY_HASH.test(hash)) return null;
+
+	return `${ANON_DIRECTORY_PREFIX}${hash}`;
+};
+
+const withNpmDrain = async <T>(resourcesDirectory: string, key: string, drain: () => Promise<T>) =>
+	withFilesystemLock(
+		{
+			lockPath: getNpmLockPath(resourcesDirectory, key),
+			label: `clear.npm.${key}`,
+			quiet: true
+		},
+		drain
+	);
+
+const classifyTopLevelCache = async (cachePath: string) => {
+	if (!(await directoryExists(cachePath))) return 'skip' as const;
+	if (await pathExists(path.join(cachePath, '.btca-npm-meta.json'))) return 'npm' as const;
+	if (await pathExists(path.join(cachePath, '.git'))) return 'git' as const;
+	return 'unknown' as const;
+};
+
+const recordHandled = (handledPaths: Set<string>, ...identities: string[]) => {
+	for (const identity of identities) {
+		handledPaths.add(identity);
+	}
+};
+
+const drainGitMirrorKey = async (resourcesDirectory: string, key: string) =>
+	removeClearedTrashPaths(
+		(
+			await withGitDrain(resourcesDirectory, key, async () => {
+				const trashPath = await moveDirectoryToClearTrashIfExists(
+					resourcesDirectory,
+					getGitMirrorPath(resourcesDirectory, key)
+				);
+				return trashPath ? [trashPath] : [];
+			})
+		).filter(Boolean)
+	);
+
+const drainAnonymousGitTmpDirectories = async (
+	resourcesDirectory: string,
+	key: string,
+	entries: readonly string[]
+) =>
+	removeClearedTrashPaths(
+		await withGitDrain(resourcesDirectory, key, async () => {
+			const trashPaths: string[] = [];
+			for (const entry of entries) {
+				const trashPath = await moveDirectoryToClearTrashIfExists(
+					resourcesDirectory,
+					path.join(getTmpCacheRoot(resourcesDirectory), entry)
+				);
+				if (trashPath) {
+					trashPaths.push(trashPath);
+				}
+			}
+			return trashPaths;
+		})
+	);
+
+const drainNpmCacheKey = async (
+	resourcesDirectory: string,
+	key: string,
+	options: {
+		readonly includeTopLevel?: boolean;
+		readonly includeTmp?: boolean;
+	}
+) =>
+	removeClearedTrashPaths(
+		await withNpmDrain(resourcesDirectory, key, async () => {
+			const trashPaths: string[] = [];
+			if (options.includeTopLevel !== false) {
+				const trashPath = await moveDirectoryToClearTrashIfExists(
+					resourcesDirectory,
+					getTopLevelCachePath(resourcesDirectory, key)
+				);
+				if (trashPath) {
+					trashPaths.push(trashPath);
+				}
+			}
+			if (options.includeTmp === true) {
+				const trashPath = await moveDirectoryToClearTrashIfExists(
+					resourcesDirectory,
+					getTmpCachePath(resourcesDirectory, key)
+				);
+				if (trashPath) {
+					trashPaths.push(trashPath);
+				}
+			}
+			return trashPaths;
+		})
+	);
+
+const sweepRemainingGitMirrors = async (resourcesDirectory: string, handledPaths: Set<string>) => {
+	let cleared = 0;
+	for (const key of await listDirectoryEntriesSorted(getGitMirrorRoot(resourcesDirectory))) {
+		const identity = `mirror:${key}`;
+		if (handledPaths.has(identity)) continue;
+		recordHandled(handledPaths, identity);
+		cleared += await drainGitMirrorKey(resourcesDirectory, key);
+	}
+	return cleared;
+};
+
+const sweepRemainingTopLevelCaches = async (
+	resourcesDirectory: string,
+	handledPaths: Set<string>
+) => {
+	let cleared = 0;
+	for (const key of await listDirectoryEntriesSorted(resourcesDirectory)) {
+		if ([CLEAR_TRASH_DIR, GIT_MIRRORS_DIR, RESOURCE_LOCKS_DIR, TMP_DIR].includes(key)) continue;
+
+		const identity = `top:${key}`;
+		if (handledPaths.has(identity)) continue;
+
+		const cachePath = getTopLevelCachePath(resourcesDirectory, key);
+		const classification = await classifyTopLevelCache(cachePath);
+		if (classification === 'skip') continue;
+
+		if (classification === 'npm') {
+			recordHandled(handledPaths, identity);
+			cleared += await drainNpmCacheKey(resourcesDirectory, key, { includeTopLevel: true });
+			continue;
+		}
+
+		if (classification === 'git') {
+			recordHandled(handledPaths, identity);
+			cleared += await removeClearedTrashPaths(
+				(
+					await withGitDrain(resourcesDirectory, key, async () => {
+						const trashPath = await moveDirectoryToClearTrashIfExists(
+							resourcesDirectory,
+							cachePath
+						);
+						return trashPath ? [trashPath] : [];
+					})
+				).filter(Boolean)
+			);
+			continue;
+		}
+
+		const trashPath = await moveDirectoryToClearTrashIfExists(resourcesDirectory, cachePath);
+		if (trashPath) {
+			recordHandled(handledPaths, identity);
+			cleared += await removeClearedTrashPaths([trashPath]);
+			metricsInfo('resources.clear.unknown_legacy_cache', {
+				path: cachePath,
+				key
+			});
+		}
+	}
+	return cleared;
+};
+
+const sweepClearTrashRoot = async (resourcesDirectory: string) => {
+	for (const entry of await listDirectoryEntriesSorted(getClearTrashRoot(resourcesDirectory))) {
+		await removeDirectoryWithRetries(path.join(getClearTrashRoot(resourcesDirectory), entry));
+	}
+};
+
+const sweepRemainingTmpCaches = async (resourcesDirectory: string, handledPaths: Set<string>) => {
+	let cleared = 0;
+	const anonymousGitTmpEntriesByKey = new Map<string, string[]>();
+	const npmTmpKeys: string[] = [];
+
+	for (const entry of await listDirectoryEntriesSorted(getTmpCacheRoot(resourcesDirectory))) {
+		const identity = `tmp:${entry}`;
+		if (handledPaths.has(identity)) continue;
+		recordHandled(handledPaths, identity);
+
+		const anonymousGitKey = parseAnonymousGitTmpDirectoryKey(entry);
+		if (anonymousGitKey) {
+			const entries = anonymousGitTmpEntriesByKey.get(anonymousGitKey) ?? [];
+			entries.push(entry);
+			anonymousGitTmpEntriesByKey.set(anonymousGitKey, entries);
+			continue;
+		}
+
+		npmTmpKeys.push(entry);
+	}
+
+	for (const [key, entries] of anonymousGitTmpEntriesByKey) {
+		cleared += await drainAnonymousGitTmpDirectories(resourcesDirectory, key, entries);
+	}
+
+	for (const key of npmTmpKeys) {
+		cleared += await drainNpmCacheKey(resourcesDirectory, key, {
+			includeTopLevel: false,
+			includeTmp: true
+		});
+	}
+
+	return cleared;
+};
+
+export const createResourcesService = (
+	config: ConfigServiceShape,
+	deps?: ResourcesServiceDeps
+): ResourcesService => {
 	const loadPromise: ResourcesService['loadPromise'] = async (name, options) => {
 		const quiet = options?.quiet ?? false;
 		const definition = resolveResourceDefinition(name, config.getResource);
@@ -161,7 +497,8 @@ export const createResourcesService = (config: ConfigServiceShape): ResourcesSer
 		if (isGitResource(definition)) {
 			try {
 				return await loadGitResource(
-					definitionToGitArgs(definition, config.resourcesDirectory, quiet)
+					definitionToGitArgs(definition, config.resourcesDirectory, quiet),
+					deps?.git
 				);
 			} catch (cause) {
 				if (cause instanceof ResourceError) throw cause;
@@ -175,7 +512,10 @@ export const createResourcesService = (config: ConfigServiceShape): ResourcesSer
 
 		if (isNpmResource(definition)) {
 			try {
-				return await loadNpmResource(definitionToNpmArgs(definition, config.resourcesDirectory));
+				return await loadNpmResource(
+					definitionToNpmArgs(definition, config.resourcesDirectory, quiet),
+					deps?.npm
+				);
 			} catch (cause) {
 				if (cause instanceof ResourceError) throw cause;
 				throw new ResourceError({
@@ -187,6 +527,64 @@ export const createResourcesService = (config: ConfigServiceShape): ResourcesSer
 		}
 
 		return loadLocalResource(definitionToLocalArgs(definition));
+	};
+
+	const clearCachesPromise: ResourcesService['clearCachesPromise'] = async () => {
+		const lockPath = getClearLockPath(config.resourcesDirectory);
+		return withFilesystemLock(
+			{
+				lockPath,
+				label: 'resources.clear',
+				quiet: true
+			},
+			async () => {
+				let clearedCount = 0;
+				const handledPaths = new Set<string>();
+				const currentNamedGitKeys = getCurrentNamedGitKeys(config.resources);
+				const currentNamedNpmKeys = getCurrentNamedNpmKeys(config.resources);
+				const { extraGitKeys, extraNpmKeys } = await getExtraActiveLockKeys(
+					config.resourcesDirectory,
+					{
+						currentNamedGitKeys,
+						currentNamedNpmKeys
+					}
+				);
+
+				for (const key of currentNamedGitKeys) {
+					recordHandled(handledPaths, `mirror:${key}`);
+					clearedCount += await drainGitMirrorKey(config.resourcesDirectory, key);
+				}
+
+				for (const key of currentNamedNpmKeys) {
+					recordHandled(handledPaths, `top:${key}`);
+					clearedCount += await drainNpmCacheKey(config.resourcesDirectory, key, {
+						includeTopLevel: true
+					});
+				}
+
+				for (const key of extraGitKeys) {
+					recordHandled(handledPaths, `mirror:${key}`);
+					clearedCount += await drainGitMirrorKey(config.resourcesDirectory, key);
+				}
+
+				for (const key of extraNpmKeys) {
+					recordHandled(handledPaths, `top:${key}`, `tmp:${key}`);
+					clearedCount += await drainNpmCacheKey(config.resourcesDirectory, key, {
+						includeTopLevel: true,
+						includeTmp: true
+					});
+				}
+
+				clearedCount += await sweepRemainingGitMirrors(config.resourcesDirectory, handledPaths);
+				clearedCount += await sweepRemainingTopLevelCaches(config.resourcesDirectory, handledPaths);
+				clearedCount += await sweepRemainingTmpCaches(config.resourcesDirectory, handledPaths);
+				await sweepClearTrashRoot(config.resourcesDirectory);
+
+				await mkdir(getResourceLocksRoot(config.resourcesDirectory), { recursive: true });
+
+				return { cleared: clearedCount };
+			}
+		);
 	};
 
 	const load: ResourcesService['load'] = (name, options) =>
@@ -204,6 +602,12 @@ export const createResourcesService = (config: ConfigServiceShape): ResourcesSer
 
 	return {
 		load,
-		loadPromise
+		loadPromise,
+		clearCaches: () =>
+			Effect.tryPromise({
+				try: () => clearCachesPromise(),
+				catch: (cause) => cause
+			}),
+		clearCachesPromise
 	};
 };

--- a/apps/server/src/resources/service.ts
+++ b/apps/server/src/resources/service.ts
@@ -74,7 +74,7 @@ export type ResourcesService = {
 			quiet?: boolean;
 		}
 	) => Promise<BtcaFsResource>;
-	clearCaches: () => Effect.Effect<{ cleared: number }, unknown, never>;
+	clearCaches: () => Effect.Effect<{ cleared: number }, ResourceError, never>;
 	clearCachesPromise: () => Promise<{ cleared: number }>;
 };
 
@@ -490,6 +490,15 @@ export const createResourcesService = (
 	config: ConfigServiceShape,
 	deps?: ResourcesServiceDeps
 ): ResourcesService => {
+	const normalizeClearError = (cause: unknown) =>
+		cause instanceof ResourceError
+			? cause
+			: new ResourceError({
+					message: 'Failed to clear BTCA-managed resource caches',
+					hint: 'Check filesystem permissions for the BTCA data directory and try again.',
+					cause
+				});
+
 	const loadPromise: ResourcesService['loadPromise'] = async (name, options) => {
 		const quiet = options?.quiet ?? false;
 		const definition = resolveResourceDefinition(name, config.getResource);
@@ -531,60 +540,67 @@ export const createResourcesService = (
 
 	const clearCachesPromise: ResourcesService['clearCachesPromise'] = async () => {
 		const lockPath = getClearLockPath(config.resourcesDirectory);
-		return withFilesystemLock(
-			{
-				lockPath,
-				label: 'resources.clear',
-				quiet: true
-			},
-			async () => {
-				let clearedCount = 0;
-				const handledPaths = new Set<string>();
-				const currentNamedGitKeys = getCurrentNamedGitKeys(config.resources);
-				const currentNamedNpmKeys = getCurrentNamedNpmKeys(config.resources);
-				const { extraGitKeys, extraNpmKeys } = await getExtraActiveLockKeys(
-					config.resourcesDirectory,
-					{
-						currentNamedGitKeys,
-						currentNamedNpmKeys
+		try {
+			return await withFilesystemLock(
+				{
+					lockPath,
+					label: 'resources.clear',
+					quiet: true
+				},
+				async () => {
+					let clearedCount = 0;
+					const handledPaths = new Set<string>();
+					const currentNamedGitKeys = getCurrentNamedGitKeys(config.resources);
+					const currentNamedNpmKeys = getCurrentNamedNpmKeys(config.resources);
+					const { extraGitKeys, extraNpmKeys } = await getExtraActiveLockKeys(
+						config.resourcesDirectory,
+						{
+							currentNamedGitKeys,
+							currentNamedNpmKeys
+						}
+					);
+
+					for (const key of currentNamedGitKeys) {
+						recordHandled(handledPaths, `mirror:${key}`);
+						clearedCount += await drainGitMirrorKey(config.resourcesDirectory, key);
 					}
-				);
 
-				for (const key of currentNamedGitKeys) {
-					recordHandled(handledPaths, `mirror:${key}`);
-					clearedCount += await drainGitMirrorKey(config.resourcesDirectory, key);
+					for (const key of currentNamedNpmKeys) {
+						recordHandled(handledPaths, `top:${key}`);
+						clearedCount += await drainNpmCacheKey(config.resourcesDirectory, key, {
+							includeTopLevel: true
+						});
+					}
+
+					for (const key of extraGitKeys) {
+						recordHandled(handledPaths, `mirror:${key}`);
+						clearedCount += await drainGitMirrorKey(config.resourcesDirectory, key);
+					}
+
+					for (const key of extraNpmKeys) {
+						recordHandled(handledPaths, `top:${key}`, `tmp:${key}`);
+						clearedCount += await drainNpmCacheKey(config.resourcesDirectory, key, {
+							includeTopLevel: true,
+							includeTmp: true
+						});
+					}
+
+					clearedCount += await sweepRemainingGitMirrors(config.resourcesDirectory, handledPaths);
+					clearedCount += await sweepRemainingTopLevelCaches(
+						config.resourcesDirectory,
+						handledPaths
+					);
+					clearedCount += await sweepRemainingTmpCaches(config.resourcesDirectory, handledPaths);
+					await sweepClearTrashRoot(config.resourcesDirectory);
+
+					await mkdir(getResourceLocksRoot(config.resourcesDirectory), { recursive: true });
+
+					return { cleared: clearedCount };
 				}
-
-				for (const key of currentNamedNpmKeys) {
-					recordHandled(handledPaths, `top:${key}`);
-					clearedCount += await drainNpmCacheKey(config.resourcesDirectory, key, {
-						includeTopLevel: true
-					});
-				}
-
-				for (const key of extraGitKeys) {
-					recordHandled(handledPaths, `mirror:${key}`);
-					clearedCount += await drainGitMirrorKey(config.resourcesDirectory, key);
-				}
-
-				for (const key of extraNpmKeys) {
-					recordHandled(handledPaths, `top:${key}`, `tmp:${key}`);
-					clearedCount += await drainNpmCacheKey(config.resourcesDirectory, key, {
-						includeTopLevel: true,
-						includeTmp: true
-					});
-				}
-
-				clearedCount += await sweepRemainingGitMirrors(config.resourcesDirectory, handledPaths);
-				clearedCount += await sweepRemainingTopLevelCaches(config.resourcesDirectory, handledPaths);
-				clearedCount += await sweepRemainingTmpCaches(config.resourcesDirectory, handledPaths);
-				await sweepClearTrashRoot(config.resourcesDirectory);
-
-				await mkdir(getResourceLocksRoot(config.resourcesDirectory), { recursive: true });
-
-				return { cleared: clearedCount };
-			}
-		);
+			);
+		} catch (cause) {
+			throw normalizeClearError(cause);
+		}
 	};
 
 	const load: ResourcesService['load'] = (name, options) =>
@@ -606,7 +622,7 @@ export const createResourcesService = (
 		clearCaches: () =>
 			Effect.tryPromise({
 				try: () => clearCachesPromise(),
-				catch: (cause) => cause
+				catch: normalizeClearError
 			}),
 		clearCachesPromise
 	};

--- a/apps/server/src/resources/test-support.ts
+++ b/apps/server/src/resources/test-support.ts
@@ -1,0 +1,34 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { Effect } from 'effect';
+
+import type { ConfigService } from '../config/index.ts';
+
+import type { ResourceDefinition } from './schema.ts';
+
+export const createConfigServiceMock = (args: {
+	readonly resourcesDirectory: string;
+	readonly resources: readonly ResourceDefinition[];
+	readonly configPath?: string;
+}) =>
+	({
+		resourcesDirectory: args.resourcesDirectory,
+		resources: args.resources,
+		getResource: (name: string) => args.resources.find((resource) => resource.name === name),
+		reload: () => Effect.void,
+		updateModel: () => Effect.fail('not implemented'),
+		addResource: () => Effect.fail('not implemented'),
+		removeResource: () => Effect.fail('not implemented'),
+		getProviderOptions: () => undefined,
+		model: 'test-model',
+		provider: 'test-provider',
+		maxSteps: 10,
+		configPath: args.configPath ?? path.join(args.resourcesDirectory, 'btca.config.jsonc')
+	}) as unknown as ConfigService;
+
+export const createStaleLockDirectory = async (lockPath: string) => {
+	await fs.mkdir(lockPath, { recursive: true });
+	const oldDate = new Date(Date.now() - 60_000);
+	await fs.utimes(lockPath, oldDate, oldDate);
+};

--- a/apps/server/src/resources/types.ts
+++ b/apps/server/src/resources/types.ts
@@ -1,16 +1,56 @@
 export const FS_RESOURCE_SYSTEM_NOTE =
 	'This is a btca resource - a searchable knowledge source the agent can reference.';
 
-export type BtcaFsResource = {
+export type BtcaGitMaterializationMetadata = {
+	readonly url?: string;
+	readonly branch?: string;
+	readonly commit?: string;
+};
+
+export type BtcaNpmMaterializationMetadata = {
+	readonly package?: string;
+	readonly version?: string;
+	readonly url?: string;
+};
+
+export type BtcaLocalMaterializationMetadata = Record<never, never>;
+
+export type BtcaResourceMaterializationMetadata =
+	| BtcaGitMaterializationMetadata
+	| BtcaNpmMaterializationMetadata
+	| BtcaLocalMaterializationMetadata;
+
+type BtcaResourceType = 'git' | 'local' | 'npm';
+
+type BtcaMaterializationMetadataByType = {
+	readonly git: BtcaGitMaterializationMetadata;
+	readonly local: BtcaLocalMaterializationMetadata;
+	readonly npm: BtcaNpmMaterializationMetadata;
+};
+
+export type BtcaResourceMaterializationResult<TType extends BtcaResourceType = BtcaResourceType> = {
+	readonly metadata: BtcaMaterializationMetadataByType[TType];
+};
+
+type BtcaFsResourceBase<TType extends BtcaResourceType> = {
 	readonly _tag: 'fs-based';
 	readonly name: string;
 	readonly fsName: string;
-	readonly type: 'git' | 'local' | 'npm';
+	readonly type: TType;
 	readonly repoSubPaths: readonly string[];
 	readonly specialAgentInstructions: string;
-	readonly getAbsoluteDirectoryPath: () => Promise<string>;
+	readonly materializeIntoVirtualFs: (args: {
+		readonly destinationPath: string;
+		readonly vfsId: string;
+	}) => Promise<BtcaResourceMaterializationResult<TType>>;
 	readonly cleanup?: () => Promise<void>;
 };
+
+export type BtcaGitFsResource = BtcaFsResourceBase<'git'>;
+export type BtcaLocalFsResource = BtcaFsResourceBase<'local'>;
+export type BtcaNpmFsResource = BtcaFsResourceBase<'npm'>;
+
+export type BtcaFsResource = BtcaGitFsResource | BtcaLocalFsResource | BtcaNpmFsResource;
 
 export type BtcaGitResourceArgs = {
 	readonly type: 'git';
@@ -39,6 +79,7 @@ export type BtcaNpmResourceArgs = {
 	readonly version?: string;
 	readonly resourcesDirectoryPath: string;
 	readonly specialAgentInstructions: string;
+	readonly quiet: boolean;
 	readonly ephemeral?: boolean;
 	readonly localDirectoryKey?: string;
 };

--- a/apps/web/static/llms.txt
+++ b/apps/web/static/llms.txt
@@ -51,7 +51,7 @@ It ships:
   - Remove a resource from config (with confirmation).
 
 - `btca clear`
-  - Clear all locally cloned resources.
+  - Clear BTCA-managed local resource caches, including named git mirrors, temporary anonymous git caches, and npm caches.
 - `btca serve --port <port>`
   - Start the local server.
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/cli": {
       "name": "btca",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "bin": {
         "btca": "bin.js",
       },
@@ -69,7 +69,7 @@
     },
     "apps/server": {
       "name": "btca-server",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.23",
         "@ai-sdk/google": "^3.0.13",


### PR DESCRIPTION
## Summary
This makes BTCA's cache-backed resource materialization safe across concurrent CLI and server processes by moving resources onto a shared `materializeIntoVirtualFs(...)` seam and coordinating cache mutation through filesystem locks. BTCA needs this because separate processes currently share one on-disk cache root, so git updates, npm hydration, and `btca clear` can collide and leave caches in a broken or partially cleared state. A little over half of the added lines are test coverage (`3,696` of `5,765`)

## Motivation
I first ran into this while working across multiple worktrees of the same project. Those worktrees could end up invoking BTCA against the same named resource at the same time. In the old implementation, separate BTCA processes could share one on-disk cache and run in-place git update operations on that same checkout without cross-process coordination, which could leave the cached resource in a bad or unusable state from BTCA's point of view. In practice, the recovery path was often to clear the cached resource and let BTCA fetch it again. No tracking issue, this came from real concurrent-worktree usage, not a filed bug.

## Review request
Please focus review on:
- correctness of the lock lifecycle and stale-lock recovery in `apps/server/src/resources/lock.ts`
- whether the git/npm materialization behavior still matches BTCA's current resource model
- whether the new `clear` flow preserves the right cache boundaries and lock identities

Lower-priority feedback for this pass:
- fixture naming/style
- wording polish in docs unless something reads incorrectly

This PR is larger than ideal in file count, but the seam change, lock layer, and subprocess race coverage are tightly coupled. A little over half of the added lines are test coverage (`3,696` of `5,765`), mostly around subprocess race cases and lock behavior. I split it into 5 commits so it can be reviewed in order instead of as one 37-file diff.

Suggested review order:
1. `cecfa6a` `feat(resources): make materialization cache-backed and lock-aware`
   - start with `apps/server/src/resources/lock.ts`, `apps/server/src/resources/layout.ts`, `apps/server/src/resources/service.ts`
   - then `apps/server/src/resources/impls/git.ts`, `apps/server/src/resources/impls/npm.ts`, `apps/server/src/resources/impls/local.ts`
   - finish with `apps/server/src/collections/service.ts`, `apps/server/src/collections/types.ts`, `apps/server/src/errors.ts`
2. `0e37cb0` `test(resources): cover lock-aware materialization races`
3. `6c5857f` `docs(btca): describe lock-aware cache clearing`
4. `f7ff1c4` `chore(docs): run Mint through bunx`
5. `73d1bc7` `fix(resources): tighten cache recovery follow-ups`

If more implementation detail is useful, I attached the living ExecPlan used during the work in a PR comment. It includes the decision log, accepted review feedback, and validation checkpoints.

## Approach
- introduced a resource-owned `materializeIntoVirtualFs(...)` seam so collections stop reading raw cache paths directly
- added heartbeat-backed filesystem locking with stale recovery, clear-aware retrying, and namespace-safe lock parsing
- moved named git caches under `.git-mirrors/<key>/repo`, switched anonymous git to unique temp dirs, and used `git ls-remote --exit-code --heads` to decide anonymous fallback branches
- made npm hydration/import/cleanup coordinate on per-cache locks and return metadata directly from resource materialization
- moved cache clearing out of config into the resources service and made `/clear` lock-aware for git mirrors, npm caches, anonymous tmp caches, and legacy leftovers
- updated the docs/OpenAPI text to describe `/clear` in terms of cache-backed resource data instead of only cloned repos
- switched docs validation scripts to `bunx mint ...` so docs checks work in a clean Bun-only environment

Why this shape:
- BTCA is multi-process by default, each CLI invocation starts its own in-process server. In-process coordination can't reach across those boundaries, so the lock needs to work cross-process without a broker. Directory-based `mkdir` is atomic on POSIX and works cross-process without additional runtime support.
- The old resource interface (`getAbsoluteDirectoryPath`) returned a raw cache path and let collections read from it later. That left a gap where another process could mutate the checkout between path resolution and VFS import. `materializeIntoVirtualFs` closes that gap — the lock covers reconcile through import as one unit.
- Named git moved under `.git-mirrors/` to stop sharing the flat `<resourcesDir>/<key>/` namespace with npm. Anonymous git switched from one deterministic shared path per key to `mkdtemp`, so two concurrent requests for the same URL can't wipe each other mid-clone.

Scope boundaries:
- no CLI flags or endpoint shapes changed
- no new external dependencies were added
- same-resource requests still queue through materialization; this keeps the v1 correctness-first tradeoff instead of trying to parallelize cache mutation
- anonymous git fallback remains branch-only in this batch
- no UI changes

## Upgrade and compatibility
- No user-facing breaking changes: CLI flags, HTTP endpoints, and the `/clear` response schema are unchanged.
- Internal TypeScript API changes: `BtcaFsResource.getAbsoluteDirectoryPath` is replaced by `materializeIntoVirtualFs`, `ConfigService.clearResources()` moved to `ResourcesService.clearCaches()`, and `ServerLayerDependencies` gains a required `resources` field.
- Cache layout on upgrade: named git caches move from `<resourcesDir>/<key>/` to `.git-mirrors/<key>/`. The server re-fetches into the new layout on first use, no manual step needed. Old directories sit unused until `btca clear`, which detects and removes legacy layouts lock-safely. Anonymous git now uses unique temp dirs under `.tmp/` instead of one shared path per key. All new internal directories (`.git-mirrors/`, `.resource-locks/`, `.clear-trash/`) live inside the existing resources directory.




## Verification
Ran:
- `bun test apps/server/src/errors.test.ts`
- `bun test apps/server/src/resources/lock.test.ts`
- `bun test apps/server/src/resources/impls/git.test.ts`
- `bun test apps/server/src/resources/impls/npm.test.ts`
- `bun test apps/server/src/resources/service.test.ts`
- `bun test apps/server/src/collections/service.test.ts`
- `bun run format:server`
- `bun run check:server`
- `bun run test:server`
- `bun --cwd apps/docs run format`
- `bun --cwd apps/docs run check`
- `bunx mint validate`

`bun run test:server` finished with `104 pass / 4 skip / 0 fail`.

Isolated CLI smoke also passed using the repo-local CLI only with a temp `HOME`, temp `XDG_DATA_HOME`, temp project config, and temp `.btca` data dir so the installed BTCA setup was not touched:
- `status` passed
- `resources` passed
- warm-up `ask` against the named git resource passed
- 4 parallel `ask` processes against the same named git resource passed
- post-parallel `ask` passed
- `btca clear` passed (`Cleared 1 resource(s).`)
- post-clear `ask` passed
- smoke logs showed no lock/git contention signatures

 \*see comments for a copy/paste prompt to recreate this test locally

## Provenance
AI assistance was substantial in implementation and review iteration. The branch was reviewed by:
- Codex CLI (local review)
- Codex GitHub PR bot
- Claude Code's code review skill
- ChatGPT 5.4 Pro
- Gemini DeepThink

The full branch, the implementation plan, and the PR description were also uploaded to ChatGPT 5.4 Pro and Gemini DeepThink for deep review.

I am not claiming a personal line-by-line final diff review here. The confidence for this draft comes from the executed test/docs checks above plus the external AI review passes over the full branch and plan. A human is still opening and maintaining the PR and will handle review follow-up.

## Supporting materials
Attached as PR comments:
1. **ChatGPT 5.4 Pro review prompt** — structured audit methodology requiring evidence-anchored findings, distrust of prior agent claims, phased extraction before evaluation, and a reverse-check step that verifies the premises behind the merge verdict
2. **ChatGPT 5.4 Pro review report** — spec compliance matrix, architecture assessment, edge case audit, and merge verdict with quality grade
3.  **Gemini Deep Think review report** — spec compliance matrix, architecture assessment, edge case audit, and merge verdict with quality grade
4. **ExecPlan** — the living implementation plan with decision log, accepted review feedback, and validation checkpoints

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes BTCA's cache-backed resource materialization concurrency-safe by introducing a `materializeIntoVirtualFs(...)` seam on resources and coordinating cache mutation through filesystem locks. The key architectural change replaces the old `getAbsoluteDirectoryPath()` with a lock-protected materialization call that covers reconcile-through-VFS-import as one atomic unit, closing the race window where another process could mutate a checkout between path resolution and import.

- **Lock layer** (`lock.ts`): New heartbeat-backed filesystem locking using atomic `mkdir`, with stale lock recovery via claim directories and clear-aware retry logic
- **Cache layout** (`layout.ts`): Named git caches moved under `.git-mirrors/<key>/repo`, anonymous git uses unique temp dirs via `mkdtemp`, new internal directories (`.resource-locks/`, `.clear-trash/`, `.tmp/`)
- **Resource implementations**: Git and npm resources now acquire clear-aware locks before reconciling caches and importing into VFS; anonymous git uses `ls-remote` to probe branches before cloning
- **Cache clearing**: Moved from `ConfigService` to `ResourcesService` with lock-aware sweep logic that drains active resource work before removing caches, handles legacy layouts
- **Collections simplification**: `CollectionsService` no longer needs `ConfigService` — delegates all materialization and metadata to resources directly
- **Docs and scripts**: Updated spec, CLI reference, and OpenAPI docs to describe lock-aware clearing; switched `mint` commands to `bunx mint` for Bun-only environments

No plan `.md` files were found in the repository. No CLI flags, endpoint shapes, or response schemas changed. Over half the added lines (3,696 of 5,765) are test coverage.

<h3>Confidence Score: 4/5</h3>

- This PR is well-structured with strong test coverage and no user-facing breaking changes; one temp dir cleanup issue in anonymous git error path should be addressed.
- Score reflects thorough test coverage (3,696 lines), clean architectural separation, no external dependency additions, and passing type checks/tests. Deducted one point for the temp dir leak in the anonymous git clone error path which could leave orphaned directories on disk during transient failures.
- Pay close attention to `apps/server/src/resources/impls/git.ts` (anonymous git temp dir cleanup on error) and `apps/server/src/resources/lock.ts` (heartbeat loop error handling readability).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/server/src/resources/lock.ts | New filesystem lock layer with heartbeat, stale recovery, and clear-aware locking. Well-structured; minor readability note on heartbeat error handling. |
| apps/server/src/resources/layout.ts | Pure path helpers for the new cache layout directories. No logic concerns. |
| apps/server/src/resources/service.ts | Moved cache clearing from ConfigService to ResourcesService with lock-aware sweep logic. Thorough handling of legacy caches and different namespace types. |
| apps/server/src/resources/impls/git.ts | Major refactor: named mirrors under `.git-mirrors/`, anonymous git uses `mkdtemp`, branch probing via `ls-remote`. Temp dir leak on clone failure in anonymous path. |
| apps/server/src/resources/impls/npm.ts | Npm resources now coordinate through clear-aware locks, atomic cache meta writes, and dependency injection for spawn. VFS import not injectable unlike git. |
| apps/server/src/resources/impls/local.ts | Extracted local resource materialization from collections service. Clean and straightforward VFS import with git-aware path listing. |
| apps/server/src/collections/service.ts | Significantly simplified by delegating to `materializeIntoVirtualFs` on each resource. ConfigService dependency removed. No issues found. |
| apps/server/src/resources/types.ts | Replaced `getAbsoluteDirectoryPath` with `materializeIntoVirtualFs` seam. Type-safe per-resource metadata via mapped types. |
| apps/server/src/effect/layers.ts | Added ResourcesService to the Effect layer. Required field in ServerLayerDependencies. |
| apps/server/src/index.ts | Wiring changes: resources passed to runtime, collections no longer needs config, `/clear` routes through ResourcesService. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/server/src/resources/impls/git.ts
Line: 778-782

Comment:
**Temp dir leaks on clone failure**

When `gitClone` or `ensureResolvedRepoSubPathsExist` throws, `cleanupDirectory(tempDir.path)` removes the directory contents, but the temp dir's parent entry (created by `mkdtemp`) is not removed via `removeDisposableTempDir(tempDir)`. The `throw error` here then re-throws, and since the temp dir was created before the loop at line 744, it never gets a matching `removeDisposableTempDir` call in the error path.

Consider cleaning up the full temp dir before re-throwing:

```suggestion
		} catch (error) {
			lastBranchError = error;
			await removeDisposableTempDir(tempDir);
			throw error;
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/server/src/resources/lock.ts
Line: 446-454

Comment:
**Heartbeat swallows `AbortError`, exits on others**

The condition `if (name !== 'AbortError') { return; }` silently returns for all non-`AbortError` exceptions, and falls through (doing nothing extra) for `AbortError` itself. This means `AbortError` — the expected case when `stop()` is called — also silently falls through to the end of the IIFE with no issue. Since the heartbeat is best-effort, swallowing unexpected errors is defensible, but the inverted-looking condition could confuse future readers. A brief comment clarifying that both paths intentionally end the loop silently would help.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 73d1bc7</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - ALWAYS follow this rule. ([source](https://app.greptile.com/review/custom-context?memory=e80e92fd-1dc2-4aa8-8ba1-f13e16e94239))

<!-- /greptile_comment -->