### PR TITLE
Clear and concise grammar tends to perform better with agents

### DIFF
--- a/skills/btca-local/SKILL.md
+++ b/skills/btca-local/SKILL.md
@@ -5,55 +5,51 @@ description: Invoke this skill when the user says "use btca"
 
 # BTCA Local
 
-BTCA Local, aka "The Better Context App Local" is a simple app defined as a skill file. The purpose of this app is to search git repos cloned onto this machine.
+BTCA Local, aka "The Better Context App Local" is a simple app defined as a skill file. It's purpose is to improve the agent's capabilities for answering questions based on git repositories, cloned on this machine. 
 
 ## the BTCA Search Workflow
 
 <guidelines>
     <guideline>
-        if the user includes a direct like to a github repo, always load and reference that
+        If the user includes a direct like to a github repo, always load and reference that.
     </guideline>
     <guideline>
-        if the user doesn't include any specific links/repos they want you to use, do your best to guess based on the context provided
+        If the user doesn't include any specific links/repos, do your best to guess based on the provided context.
     </guideline>
     <guideline>
-        always include links/citations in your answers explaining what you found
+        Always include links and citations in your answers explaining what you found.
     </guideline>
     <guideline>
-        include very clear and complete code snippets. don't leave out stuff like imports, that's important context
+        Include very clear and complete code snippets. Don't leave out imports and error handling, that's an important context.
     </guideline>
     <guideline>
-        when answering use lots of bulleted/numbered lists to keep things readable and clear
+        Be extremly concise in all interactions. Sacrifice grammer for the sake of concision.
     </guideline>
 </guidelines>
 
 <workflow>
     <step name="work dir setup">
-        use ~/.btca/agent/sandbox as the place where you clone/search repos
+        Store your cloned repositories into `~/.btca/agent/sandbox`.
     </step>
     <step name="load">
-        if the repo(s) are already in the work dir ~/.btca/agent/sandbox update them, otherwise clone them. clone the main branch by default, unless the user asks for something else
+        If the repository is already inside your working directory `~/.btca/agent/sandbox`, update it, otherwise clone it. Clone the main branch, unless the user specifies otherwise.
     </step>
     <step name="search">
-        search the repo for the information you need. make sure to follow the guidelines
+        Search the repository for the required information. Make sure you follow the guidelines.
     </step>
 <workflow>
 
 <end_goal>
-a clear, concise answer to the question with code examples
+    A clear and concise answer to the question with code examples.
 </end_goal>
 
 ## Startup Cases:
 
-This skill can be invoked in a couple different ways, and your behavior should reflect that:
+This skill can be invoked in the following ways. Make sure your behaviour reflects that.
 
-### user invoked without extra context/question
+### User invoked you without a question
 
-this is the "app startup" state, almost as if a terminal app was booted up.
-
-Your job is to search the working directory ~/.btca/agent/sandbox at the top level, just to get a list of all the repos that have been previously cloned
-
-Then you should simply output the following markdown (filling in the existing repos):
+Start by searching inside the top level of your working directory `~/.btca/agent/sandbox` to get a list of all previously cloned repositories. Then output the following markdown:
 
 ```md
 # BTCA Local
@@ -69,10 +65,12 @@ Give me a question and the link to a git repo to get started!
 (we can also clean out or pre-load some resources to this list...)
 ```
 
-### you invoked because of user's prompt
+This is an "app startup" state, similar to being launched inside as a terminal application. 
 
-in this case, your job is to answer/execute the users prompt faithfully, just while also using the btca search workflow when needed to better execute your task
+### You have been invoked because of the user's prompt
 
-### user invoked while also giving a prompt/questions
+Answer and execute the user's prompt. Use the BTCA search workflow to improve your understanding of the users context.
 
-this one's simple, simply answer the users prompt with the btca search workflow
+### User manually invoked you while providing a question or prompt
+
+Answer the prompt using the BTCA search workflow.


### PR DESCRIPTION
Refine language for clarity and conciseness in guidelines and workflow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update BTCA skill instructions to prioritize concision over formatted lists
> Rewrites [SKILL.md](https://github.com/davis7dotsh/better-context/pull/221/files#diff-d406fb044e217fd84e56944713f9fe5ea12b18b7c528d4654a111e44776d43ce) to improve agent instruction clarity. The output style guideline shifts from using bulleted/numbered lists to being extremely concise, favoring brevity over grammar. Code example guidance is expanded to include error handling alongside imports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f279964.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines wording in `skills/btca-local/SKILL.md` for clarity and conciseness. Most edits are improvements, but one guideline change removes the instruction to use structured lists and replaces it with advice to "sacrifice grammar" — directly contradicting the PR's stated goal — along with two typos (`extremly`, `grammer`). No plan `.md` files were detected in this PR.

<h3>Confidence Score: 4/5</h3>

Hold for the guideline replacement on line 26 — it drops structured-output behavior and introduces typos into the agent instructions.

One P1 finding (functional regression in agent guideline) warrants a 4 rather than 5; all other findings are P2 typos.

skills/btca-local/SKILL.md — specifically line 26 where the guideline was replaced.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| skills/btca-local/SKILL.md | Language refined for clarity throughout, but an original structured-output guideline was dropped and replaced with a typo-laden instruction to "sacrifice grammar," which is a functional regression for agent behavior. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: skills/btca-local/SKILL.md
Line: 26

Comment:
**Guideline replaced + typos in new text**

This replaces the original instruction to "use lots of bulleted/numbered lists to keep things readable and clear" with advice to "Sacrifice grammer for the sake of concision" — which removes structured-output behavior entirely and introduces two typos (`extremly`, `grammer`). Agent instructions like this directly shape output quality, so dropping the list/readability guideline is a functional regression, and the misspellings undermine the PR's stated goal of improving grammar clarity.

```suggestion
        Be extremely concise in all interactions. Use bulleted or numbered lists to keep answers readable and clear.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: skills/btca-local/SKILL.md
Line: 8

Comment:
**"It's" should be "Its"**

`It's` is a contraction for "it is"; the possessive form `Its` is needed here.

```suggestion
BTCA Local, aka "The Better Context App Local" is a simple app defined as a skill file. Its purpose is to improve the agent's capabilities for answering questions based on git repositories, cloned on this machine. 
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Clear and concise grammar tends to perfo..."](https://github.com/davis7dotsh/better-context/commit/f2799641077d12b01999e9ed1cc2686bbb7abe82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28126044)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->