### PR TITLE
fix: small typo on skill

### DIFF
--- a/skills/btca-local/SKILL.md
+++ b/skills/btca-local/SKILL.md
@@ -11,7 +11,7 @@ BTCA Local, aka "The Better Context App Local" is a simple app defined as a skil
 
 <guidelines>
     <guideline>
-        if the user includes a direct like to a github repo, always load and reference that
+        if the user includes a direct link to a github repo, always load and reference that
     </guideline>
     <guideline>
         if the user doesn't include any specific links/repos they want you to use, do your best to guess based on the context provided


### PR DESCRIPTION
Very small typo, makes more sense to be 'github link'

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a single-word typo in `skills/btca-local/SKILL.md`, changing "direct like" to "direct link" in a guideline element. No existing features are affected and no plan files were found in the repository.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a documentation typo fix with no functional impact.

Single-word typo correction in a markdown skill file. No logic, no code, no breaking changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| skills/btca-local/SKILL.md | Single-word typo fix: "like" → "link" in a guideline description. No functional changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: small typo on skill"](https://github.com/davis7dotsh/better-context/commit/b5ecec3a4e847fba22e7987e4e54721f241c8a5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28139469)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix typo in `btca-local` skill documentation
> Corrects 'direct like' to 'direct link' in [SKILL.md](https://github.com/davis7dotsh/better-context/pull/224/files#diff-d406fb044e217fd84e56944713f9fe5ea12b18b7c528d4654a111e44776d43ce).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5ecec3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->