### PR TITLE
Fix Linux clipboard copy by adding OSC52 fallback

### DIFF
--- a/apps/cli/src/tui/clipboard.test.ts
+++ b/apps/cli/src/tui/clipboard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getOsc52Sequence, tryOsc52Copy } from './clipboard.ts';
+
+describe('clipboard OSC52 fallback', () => {
+	test('builds a valid OSC52 sequence', () => {
+		expect(getOsc52Sequence('hello')).toBe('\u001b]52;c;aGVsbG8=\u0007');
+	});
+
+	test('does not copy when stdout is not TTY', () => {
+		const writes: string[] = [];
+		const ok = tryOsc52Copy('hello', {
+			isTTY: false,
+			term: 'xterm-256color',
+			write: (value) => writes.push(value)
+		});
+		expect(ok).toBe(false);
+		expect(writes).toHaveLength(0);
+	});
+
+	test('does not copy on dumb terminal', () => {
+		const writes: string[] = [];
+		const ok = tryOsc52Copy('hello', {
+			isTTY: true,
+			term: 'dumb',
+			write: (value) => writes.push(value)
+		});
+		expect(ok).toBe(false);
+		expect(writes).toHaveLength(0);
+	});
+
+	test('writes OSC52 sequence on compatible terminal', () => {
+		const writes: string[] = [];
+		const ok = tryOsc52Copy('hello', {
+			isTTY: true,
+			term: 'xterm-256color',
+			write: (value) => writes.push(value)
+		});
+		expect(ok).toBe(true);
+		expect(writes).toEqual(['\u001b]52;c;aGVsbG8=\u0007']);
+	});
+});

--- a/apps/cli/src/tui/clipboard.ts
+++ b/apps/cli/src/tui/clipboard.ts
@@ -87,10 +87,10 @@ export async function copyToClipboard(text: string) {
 
 		// Try xclip first, fall back to xsel
 		const xclipResult = await runClipboard(['xclip', '-selection', 'clipboard']);
-		if (!xclipResult) {
-			const xselResult = await runClipboard(['xsel', '--clipboard', '--input']);
-			if (xselResult) return;
-		}
+		if (xclipResult) return;
+
+		const xselResult = await runClipboard(['xsel', '--clipboard', '--input']);
+		if (xselResult) return;
 
 		const osc52Result = tryOsc52Copy(text);
 		if (!osc52Result) {

--- a/apps/cli/src/tui/clipboard.ts
+++ b/apps/cli/src/tui/clipboard.ts
@@ -18,6 +18,35 @@ const isWayland = () => {
 	return !!process.env.WAYLAND_DISPLAY;
 };
 
+export const getOsc52Sequence = (text: string) => {
+	const encoded = Buffer.from(text, 'utf8').toString('base64');
+	return `\u001b]52;c;${encoded}\u0007`;
+};
+
+export const tryOsc52Copy = (
+	text: string,
+	options: {
+		isTTY?: boolean;
+		term?: string;
+		write?: (value: string) => unknown;
+	} = {}
+) => {
+	const isTTY = options.isTTY ?? process.stdout.isTTY;
+	const term = options.term ?? process.env.TERM;
+	const write = options.write ?? ((value: string) => process.stdout.write(value));
+
+	if (!isTTY) return false;
+	if (term === 'dumb') return false;
+
+	try {
+		// OSC52 allows terminals to copy text to the system clipboard without external binaries.
+		write(getOsc52Sequence(text));
+		return true;
+	} catch {
+		return false;
+	}
+};
+
 export async function copyToClipboard(text: string) {
 	const platform = process.platform;
 
@@ -60,9 +89,14 @@ export async function copyToClipboard(text: string) {
 		const xclipResult = await runClipboard(['xclip', '-selection', 'clipboard']);
 		if (!xclipResult) {
 			const xselResult = await runClipboard(['xsel', '--clipboard', '--input']);
-			if (!xselResult) {
-				throw new Error('Failed to copy to clipboard: no compatible clipboard command succeeded.');
-			}
+			if (xselResult) return;
+		}
+
+		const osc52Result = tryOsc52Copy(text);
+		if (!osc52Result) {
+			throw new Error(
+				'Failed to copy to clipboard: no compatible clipboard command succeeded and terminal OSC52 fallback is unavailable.'
+			);
 		}
 	}
 }

--- a/apps/cli/src/tui/context/messages-context.tsx
+++ b/apps/cli/src/tui/context/messages-context.tsx
@@ -472,7 +472,12 @@ export const MessagesProvider = (props: { children: ReactNode }) => {
 			getAssistantMessageText(assistantMessage)
 		].join('\n');
 		try {
-			await runCliEffect(Effect.tryPromise(() => copyToClipboard(payload)));
+			await runCliEffect(
+				Effect.tryPromise({
+					try: () => copyToClipboard(payload),
+					catch: (error) => (error instanceof Error ? error : new Error(String(error)))
+				})
+			);
 		} catch (error) {
 			addMessage({ role: 'system', content: `Error: ${formatError(error)}` });
 			return;
@@ -493,7 +498,12 @@ export const MessagesProvider = (props: { children: ReactNode }) => {
 		}
 
 		try {
-			await runCliEffect(Effect.tryPromise(() => copyToClipboard(parts.join('\n\n'))));
+			await runCliEffect(
+				Effect.tryPromise({
+					try: () => copyToClipboard(parts.join('\n\n')),
+					catch: (error) => (error instanceof Error ? error : new Error(String(error)))
+				})
+			);
 		} catch (error) {
 			addMessage({ role: 'system', content: `Error: ${formatError(error)}` });
 			return;

--- a/apps/cli/src/tui/services.ts
+++ b/apps/cli/src/tui/services.ts
@@ -115,21 +115,23 @@ export const services = {
 				const chunkOrder: string[] = [];
 				let doneEvent: Extract<BtcaStreamEvent, { type: 'done' }> | undefined;
 				try {
-					yield* Effect.tryPromise(() =>
-						(async () => {
-							for await (const event of parseSSEStream(response)) {
-								if (signal.aborted) break;
-								if (event.type === 'error') {
-									throw new Error(formatTuiStreamError(event));
+					yield* Effect.tryPromise({
+						try: () =>
+							(async () => {
+								for await (const event of parseSSEStream(response)) {
+									if (signal.aborted) break;
+									if (event.type === 'error') {
+										throw new Error(formatTuiStreamError(event));
+									}
+									if (event.type === 'done') {
+										doneEvent = event;
+										continue;
+									}
+									processStreamEvent(event, chunksById, chunkOrder, onChunkUpdate);
 								}
-								if (event.type === 'done') {
-									doneEvent = event;
-									continue;
-								}
-								processStreamEvent(event, chunksById, chunkOrder, onChunkUpdate);
-							}
-						})()
-					);
+							})(),
+						catch: (e) => (e instanceof Error ? e : new Error(String(e)))
+					});
 				} catch (error) {
 					if (!(error instanceof Error && error.name === 'AbortError')) {
 						return yield* Effect.fail(error);
@@ -152,12 +154,14 @@ export const services = {
 				if (!currentAbortController) return;
 				currentAbortController.abort();
 				currentAbortController = null;
-				yield* Effect.tryPromise(() =>
-					trackTelemetryEvent({
-						event: 'cli_stream_cancelled',
-						properties: { command: 'btca', mode: 'tui' }
-					})
-				);
+				yield* Effect.tryPromise({
+					try: () =>
+						trackTelemetryEvent({
+							event: 'cli_stream_cancelled',
+							properties: { command: 'btca', mode: 'tui' }
+						}),
+					catch: (e) => (e instanceof Error ? e : new Error(String(e)))
+				});
 			})
 		);
 	},

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -187,7 +187,8 @@ REPL supports `@resource` mentions.
 
 Clipboard behavior on Linux:
 
-- btca tries `wl-copy` (Wayland), then `xclip`, then `xsel`.
+- On WSL, btca first tries Windows clipboard via `clip.exe` (including Windows path fallback).
+- It then tries `wl-copy` (Wayland), then `xclip`, then `xsel`.
 - If these binaries are unavailable, btca falls back to terminal OSC52 clipboard copy.
 - OSC52 support depends on the terminal emulator and session configuration.
 

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -185,6 +185,12 @@ REPL supports `@resource` mentions.
 - `/copy` — copy the latest user question and assistant response
 - `/copy-all` — copy the full thread (all user and assistant messages)
 
+Clipboard behavior on Linux:
+
+- btca tries `wl-copy` (Wayland), then `xclip`, then `xsel`.
+- If these binaries are unavailable, btca falls back to terminal OSC52 clipboard copy.
+- OSC52 support depends on the terminal emulator and session configuration.
+
 **TUI keyboard shortcuts**:
 
 - `Enter` — send message

--- a/apps/docs/guides/cli-reference.mdx
+++ b/apps/docs/guides/cli-reference.mdx
@@ -41,6 +41,12 @@ TUI command palette (`/`):
 - `/copy` copies the latest user question and assistant response.
 - `/copy-all` copies the full thread (all user and assistant messages).
 
+Clipboard behavior on Linux:
+
+- btca tries `wl-copy` (Wayland), then `xclip`, then `xsel`.
+- If those tools are not installed, btca falls back to terminal OSC52 clipboard copy.
+- OSC52 support depends on your terminal emulator and SSH/session settings.
+
 TUI keyboard shortcuts:
 
 - `Enter` sends message.

--- a/apps/docs/guides/cli-reference.mdx
+++ b/apps/docs/guides/cli-reference.mdx
@@ -43,7 +43,8 @@ TUI command palette (`/`):
 
 Clipboard behavior on Linux:
 
-- btca tries `wl-copy` (Wayland), then `xclip`, then `xsel`.
+- On WSL, btca first tries Windows clipboard via `clip.exe` (including Windows path fallback).
+- It then tries `wl-copy` (Wayland), then `xclip`, then `xsel`.
 - If those tools are not installed, btca falls back to terminal OSC52 clipboard copy.
 - OSC52 support depends on your terminal emulator and SSH/session settings.
 


### PR DESCRIPTION
## What happened
I tried using btca on Linux, and clipboard copy failed in my terminal setup.

## Root cause
On Linux, clipboard copy relied on external binaries (`wl-copy`, `xclip`, `xsel`). In minimal or terminal-only environments, these may be unavailable, causing copy to fail.

## What I changed
- Added an OSC52 fallback for Linux clipboard copy when system clipboard tools are unavailable.
- Improved async TUI error handling so failures are surfaced as proper `Error` values.
- Updated docs to describe Linux clipboard fallback behavior.
- Added tests for clipboard fallback behavior.

## Why this fix
OSC52 works through compatible terminals without requiring external clipboard binaries, making clipboard copy more reliable for Linux users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added OSC52 clipboard support:
  - New exported functions in apps/cli/src/tui/clipboard.ts:
    - getOsc52Sequence(text: string): string — generates Base64-encoded OSC52 UTF-8 escape.
    - tryOsc52Copy(text: string, options?): boolean — writes OSC52 to stdout when appropriate and returns success flag.
- Implemented OSC52 fallback logic for Linux clipboard:
  - Linux/WSL copy flow now attempts: clip.exe (WSL) → wl-copy → xclip → xsel, then OSC52 fallback if external commands are unavailable.
  - OSC52 is only attempted when stdout is a TTY and TERM is not "dumb".
  - When all methods fail, the thrown error now reports both external command failures and OSC52 unavailability.
- Tests:
  - Added apps/cli/src/tui/clipboard.test.ts to validate OSC52 sequence generation and tryOsc52Copy behavior under different terminal conditions (isTTY false, TERM=dumb, TERM supporting OSC52).
- Async error handling improvements:
  - Normalized error handling by converting non-Error throwables into Error instances via explicit Effect.tryPromise({ try, catch }) or equivalent in:
    - apps/cli/src/tui/context/messages-context.tsx
    - apps/cli/src/tui/services.ts
- Documentation updates:
  - apps/docs/btca.spec.md and apps/docs/guides/cli-reference.mdx updated to document Linux/WSL clipboard behavior and OSC52 caveats.
- Review/regression note:
  - Automated review flagged a potential regression where a successful xclip call might not return early and could fall through to writing OSC52 to stdout; tests were added to cover expected behavior.
- No changes to authentication service implementation or database schema/data model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux clipboard copy by adding OSC52 terminal fallback
> - Adds `getOsc52Sequence` and `tryOsc52Copy` helpers in [clipboard.ts](https://github.com/davis7dotsh/better-context/pull/225/files#diff-bbca2aa369ef73e8b27aaf2d270488d96d3f4c57423cedf6a17aa32192d86bc8) that base64-encode text and write an OSC52 escape sequence to stdout as a last-resort clipboard mechanism.
> - `copyToClipboard` on Linux now tries `wl-copy`, `xclip`, `xsel`, and OSC52 in order before throwing; the final error message text has also changed.
> - Fixes non-Error rejections from `copyToClipboard` in [messages-context.tsx](https://github.com/davis7dotsh/better-context/pull/225/files#diff-0fd40e691dc3465745ada8676a38426aee3a9c96f47b30d6674aef57cd9ee4e5) by coercing them to `Error` instances before propagation.
> - OSC52 copy is skipped when stdout is not a TTY or `TERM` is `dumb`.
> - Documents the fallback chain and OSC52 terminal dependency in [cli-reference.mdx](https://github.com/davis7dotsh/better-context/pull/225/files#diff-f341cb6db4c4a57b1c679b5f58d8a0d00962b2979f4d5e7ec0444bbc19e4fe21) and [btca.spec.md](https://github.com/davis7dotsh/better-context/pull/225/files#diff-67ff1f2eda6e9a05fee46eea3d1ce17f4407e2ac31a8ff7a44d0c390fe9c6144).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 527536c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an OSC52 terminal escape sequence fallback for Linux clipboard copy when external binaries (`wl-copy`, `xclip`, `xsel`) are unavailable, along with improved `Effect.tryPromise` error coercion and documentation updates. The early-return control flow for xclip/xsel is correct and the previously flagged xclip fallthrough regression is resolved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the OSC52 fallback logic is correct, the xclip early-return regression is fixed, and error coercion improvements are sound.

All findings are P2 style suggestions. No regressions in existing behavior were introduced; the only note is a pre-existing limitation in `runClipboard` that reduces OSC52 fallback coverage for installed-but-failing binaries.

apps/cli/src/tui/clipboard.ts — the `runClipboard` helper should check exit codes to make OSC52 fallback fully effective.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/cli/src/tui/clipboard.ts | Adds OSC52 fallback for Linux clipboard copy; early-return logic for xclip/xsel is correct, but `runClipboard` still silently succeeds on non-zero exit codes (pre-existing issue) |
| apps/cli/src/tui/clipboard.test.ts | New test file covering OSC52 sequence generation and TTY/dumb-terminal guard conditions |
| apps/cli/src/tui/context/messages-context.tsx | Effect.tryPromise updated to explicit catch form to properly coerce non-Error throws into Error instances; functionally safe change |
| apps/cli/src/tui/services.ts | Same Effect.tryPromise catch-coercion improvement as messages-context; no behavioral regression |
| apps/docs/btca.spec.md | Documents Linux clipboard fallback chain including OSC52 caveats; accurate and clear |
| apps/docs/guides/cli-reference.mdx | User-facing docs updated to describe OSC52 fallback behavior on Linux |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/cli/src/tui/clipboard.ts
Line: 64-74

Comment:
**`runClipboard` treats any completed process as success**

`await proc.exited` resolves to the exit code number and does not throw on non-zero. If `xclip` or `xsel` is installed but fails (e.g. no `$DISPLAY`, no X server running), `runClipboard` returns `true` and the early `return` fires — bypassing the OSC52 fallback entirely, which is the whole point of this PR. The user sees "Copied to clipboard" even though nothing was copied.

```ts
const runClipboard = async (command: string[]) => {
    try {
        const proc = spawn(command, { stdin: 'pipe' });
        proc.stdin.write(text);
        proc.stdin.end();
        const exitCode = await proc.exited;
        return exitCode === 0;
    } catch {
        return false;
    }
};
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): update Linux clipboard behavi..."](https://github.com/davis7dotsh/better-context/commit/527536c11345ae055f987341e9f12790f03c3b1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28854707)</sub>

<!-- /greptile_comment -->