### PR TITLE
Fix typo in skill

### DIFF
--- a/skills/btca-local/SKILL.md
+++ b/skills/btca-local/SKILL.md
@@ -11,7 +11,7 @@ BTCA Local, aka "The Better Context App Local" is a simple app defined as a skil
 
 <guidelines>
     <guideline>
-        if the user includes a direct like to a github repo, always load and reference that
+        if the user includes a direct link to a github repo, always load and reference that
     </guideline>
     <guideline>
         if the user doesn't include any specific links/repos they want you to use, do your best to guess based on the context provided


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a single-word typo in `skills/btca-local/SKILL.md`, changing "like" to "link" in a guideline that instructs the agent to load and reference a GitHub repo when the user provides a direct URL. No logic or behavior is affected.

- Typo corrected in one guideline line; no other files are touched and no existing features are impacted.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-word documentation/instruction typo fix with no functional impact.

The only change is correcting "like" to "link" in a skill instruction file. Nothing functional is modified, and no existing features are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| skills/btca-local/SKILL.md | Single-word typo fix: "like" corrected to "link" in a guideline directive — no functional or behavioral changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix typo in skill"](https://github.com/davis7dotsh/better-context/commit/a1b434a78981f7bb1dec3db098c1bac3e2f7edcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32807072)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- Fixed typo in `skills/btca-local/SKILL.md`: corrected "direct like" to "direct link" in a workflow guideline for the BTCA Local skill

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/davis7dotsh/better-context/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->