### PR TITLE
Close unterminated workflow tag in btca-local skill

### DIFF
--- a/skills/btca-local/SKILL.md
+++ b/skills/btca-local/SKILL.md
@@ -37,7 +37,7 @@ BTCA Local, aka "The Better Context App Local" is a simple app defined as a skil
     <step name="search">
         search the repo for the information you need. make sure to follow the guidelines
     </step>
-<workflow>
+</workflow>
 
 <end_goal>
 a clear, concise answer to the question with code examples


### PR DESCRIPTION
Closes #227.

Line 40 of `skills/btca-local/SKILL.md` opened a second `<workflow>` instead of closing the block. This changes it to `</workflow>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Made

- **skills/btca-local/SKILL.md**: Fixed unterminated workflow tag by replacing the erroneous `<workflow>` opening tag on line 40 with the correct `</workflow>` closing tag, ensuring the workflow block is properly closed and subsequent sections (`end_goal` and startup cases) are no longer incorrectly nested within it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unterminated `<workflow>` tag in btca-local skill
> Replaces a duplicate opening `<workflow>` tag with the correct closing `</workflow>` tag at the end of the workflow section in [SKILL.md](https://github.com/davis7dotsh/better-context/pull/228/files#diff-d406fb044e217fd84e56944713f9fe5ea12b18b7c528d4654a111e44776d43ce), making the markup well-formed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0359824.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->