### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -151,6 +151,7 @@ async function runBtcaAuth(providerId: string): Promise<boolean> {
 	}
 
 	if (
+		providerId === 'atlascloud' ||
 		providerId === 'opencode' ||
 		providerId === 'openrouter' ||
 		providerId === 'anthropic' ||

--- a/apps/cli/src/connect/constants.test.ts
+++ b/apps/cli/src/connect/constants.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+	CURATED_MODELS,
+	PROVIDER_INFO,
+	PROVIDER_MODEL_DOCS,
+	PROVIDER_SETUP_LINKS
+} from './constants.ts';
+
+describe('Atlas Cloud connect metadata', () => {
+	test('provides authenticated setup and a default model', () => {
+		expect(PROVIDER_INFO.atlascloud).toEqual({ label: 'Atlas Cloud', requiresAuth: true });
+		expect(CURATED_MODELS.atlascloud).toContainEqual({
+			id: 'deepseek-ai/deepseek-v4-pro',
+			label: 'DeepSeek V4 Pro'
+		});
+		expect(PROVIDER_SETUP_LINKS.atlascloud?.url).toBe('https://www.atlascloud.ai/console/api-keys');
+		expect(PROVIDER_MODEL_DOCS.atlascloud?.url).toBe('https://api.atlascloud.ai/api/v1/models');
+	});
+});

--- a/apps/cli/src/connect/constants.ts
+++ b/apps/cli/src/connect/constants.ts
@@ -1,4 +1,5 @@
 export const CURATED_MODELS: Record<string, { id: string; label: string }[]> = {
+	atlascloud: [{ id: 'deepseek-ai/deepseek-v4-pro', label: 'DeepSeek V4 Pro' }],
 	openai: [
 		{ id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
 		{ id: 'gpt-5.4', label: 'GPT-5.4' }
@@ -35,6 +36,7 @@ export const CURATED_MODELS: Record<string, { id: string; label: string }[]> = {
 };
 
 export const PROVIDER_INFO: Record<string, { label: string; requiresAuth: boolean }> = {
+	atlascloud: { label: 'Atlas Cloud', requiresAuth: true },
 	opencode: { label: 'OpenCode Zen', requiresAuth: true },
 	'github-copilot': { label: 'GitHub Copilot', requiresAuth: true },
 	anthropic: { label: 'Anthropic (Claude)', requiresAuth: true },
@@ -46,6 +48,7 @@ export const PROVIDER_INFO: Record<string, { label: string; requiresAuth: boolea
 };
 
 export const PROVIDER_AUTH_GUIDANCE: Record<string, string> = {
+	atlascloud: 'Atlas Cloud uses API keys: paste your Atlas Cloud API key to continue.',
 	'github-copilot': 'GitHub Copilot uses device flow OAuth: follow the browser prompt.',
 	openai: 'OpenAI requires OAuth: btca will open a browser to sign in.',
 	minimax: 'MiniMax uses API keys: paste your MiniMax API key to continue.',
@@ -57,6 +60,10 @@ export const PROVIDER_AUTH_GUIDANCE: Record<string, string> = {
 };
 
 export const PROVIDER_MODEL_DOCS: Record<string, { label: string; url: string }> = {
+	atlascloud: {
+		label: 'Model catalog',
+		url: 'https://api.atlascloud.ai/api/v1/models'
+	},
 	openai: { label: 'Model docs', url: 'https://platform.openai.com/docs/models' },
 	'openai-compat': {
 		label: 'OpenAI-compatible docs',
@@ -82,6 +89,10 @@ export const PROVIDER_MODEL_WARNINGS: Record<string, string> = {
 };
 
 export const PROVIDER_SETUP_LINKS: Record<string, { label: string; url: string }> = {
+	atlascloud: {
+		label: 'Get Atlas Cloud API key',
+		url: 'https://www.atlascloud.ai/console/api-keys'
+	},
 	opencode: { label: 'Get OpenCode Zen API key', url: 'https://opencode.ai/zen' },
 	minimax: {
 		label: 'Get MiniMax API key',

--- a/apps/docs/btca.spec.md
+++ b/apps/docs/btca.spec.md
@@ -43,6 +43,7 @@ btca reads credentials from OpenCode’s auth storage:
 
 Supported providers:
 
+- `atlascloud` — API key
 - `opencode` — API key
 - `openrouter` — API key
 - `openai` — OAuth (no API keys)
@@ -53,6 +54,8 @@ Supported providers:
 
 Environment variable overrides:
 
+- `ATLASCLOUD_API_KEY` (for provider `atlascloud`)
+- `ATLASCLOUD_BASE_URL` (optional Atlas Cloud endpoint override)
 - `OPENCODE_API_KEY` (for provider `opencode`)
 - `OPENROUTER_API_KEY` (for provider `openrouter`)
 - `MINIMAX_API_KEY` (for provider `minimax`)
@@ -63,7 +66,7 @@ Environment variable overrides:
 
 - If provider is `openai`, runs local OAuth flow (PKCE) and writes tokens into OpenCode auth.
 - If provider is `openai-compat`, prompts for base URL, provider name, model ID, and optional API key.
-- If provider is `opencode`, `openrouter`, `anthropic`, `google`, or `minimax`, prompts for API key and writes into OpenCode auth.
+- If provider is `atlascloud`, `opencode`, `openrouter`, `anthropic`, `google`, or `minimax`, prompts for API key and writes into OpenCode auth.
 - If provider is not handled directly, falls back to `opencode auth --provider <provider>`.
 
 **OpenAI-compatible provider inputs (and why):**

--- a/apps/docs/guides/authentication.mdx
+++ b/apps/docs/guides/authentication.mdx
@@ -12,6 +12,7 @@ btca reads credentials from OpenCode's auth storage:
 
 Supported providers:
 
+- `atlascloud` (API key)
 - `opencode` (API key)
 - `openrouter` (API key)
 - `openai` (OAuth, no API keys)
@@ -23,6 +24,8 @@ Supported providers:
 
 Environment variable overrides:
 
+- `ATLASCLOUD_API_KEY` (for provider `atlascloud`)
+- `ATLASCLOUD_BASE_URL` (optional Atlas Cloud endpoint override)
 - `OPENCODE_API_KEY` (for provider `opencode`)
 - `OPENROUTER_API_KEY` (for provider `openrouter`)
 - `MINIMAX_API_KEY` (for provider `minimax`)

--- a/apps/server/src/providers/atlascloud.test.ts
+++ b/apps/server/src/providers/atlascloud.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { getAuthStatus, getProviderAuthHint } from './auth.ts';
+import { ATLAS_CLOUD_BASE_URL, createAtlasCloud } from './atlascloud.ts';
+import { getProviderFactory, isProviderSupported } from './registry.ts';
+
+describe('Atlas Cloud provider', () => {
+	afterEach(() => {
+		delete process.env.ATLASCLOUD_API_KEY;
+	});
+
+	test('registers an OpenAI-compatible chat model', () => {
+		const factory = getProviderFactory('atlascloud');
+		expect(isProviderSupported('atlascloud')).toBe(true);
+		expect(factory).toBeDefined();
+
+		const model = createAtlasCloud({ apiKey: 'test-key' })('deepseek-ai/deepseek-v4-pro');
+		expect(model.provider).toBe('atlascloud.chat');
+		expect(model.modelId).toBe('deepseek-ai/deepseek-v4-pro');
+		expect(ATLAS_CLOUD_BASE_URL).toBe('https://api.atlascloud.ai/v1');
+	});
+
+	test('reads ATLASCLOUD_API_KEY for authentication', async () => {
+		process.env.ATLASCLOUD_API_KEY = 'test-atlas-key';
+
+		expect(await getAuthStatus('atlascloud')).toEqual({
+			status: 'ok',
+			authType: 'api',
+			apiKey: 'test-atlas-key'
+		});
+		expect(getProviderAuthHint('atlascloud')).toContain('ATLASCLOUD_API_KEY');
+	});
+});

--- a/apps/server/src/providers/atlascloud.ts
+++ b/apps/server/src/providers/atlascloud.ts
@@ -1,0 +1,26 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+export const ATLAS_CLOUD_BASE_URL = 'https://api.atlascloud.ai/v1';
+
+const readEnv = (key: string) => {
+	const value = process.env[key];
+	return value && value.trim().length > 0 ? value.trim() : undefined;
+};
+
+export function createAtlasCloud(
+	options: {
+		apiKey?: string;
+		baseURL?: string;
+		headers?: Record<string, string>;
+		name?: string;
+	} = {}
+) {
+	const provider = createOpenAICompatible({
+		name: options.name ?? 'atlascloud',
+		apiKey: options.apiKey ?? readEnv('ATLASCLOUD_API_KEY'),
+		baseURL: options.baseURL ?? readEnv('ATLASCLOUD_BASE_URL') ?? ATLAS_CLOUD_BASE_URL,
+		headers: options.headers
+	});
+
+	return (modelId: string) => provider.chatModel(modelId);
+}

--- a/apps/server/src/providers/auth.ts
+++ b/apps/server/src/providers/auth.ts
@@ -19,6 +19,7 @@ export type AuthStatus =
 	| { status: 'invalid'; authType: AuthType };
 
 const PROVIDER_AUTH_TYPES: Record<string, readonly AuthType[]> = {
+	atlascloud: ['api'],
 	opencode: ['api'],
 	'github-copilot': ['oauth'],
 	openrouter: ['api'],
@@ -35,6 +36,7 @@ const readEnv = (key: string) => {
 };
 
 const getEnvApiKey = (providerId: string) => {
+	if (providerId === 'atlascloud') return readEnv('ATLASCLOUD_API_KEY');
 	if (providerId === 'openrouter') return readEnv('OPENROUTER_API_KEY');
 	if (providerId === 'opencode') return readEnv('OPENCODE_API_KEY');
 	if (providerId === 'minimax') return readEnv('MINIMAX_API_KEY');
@@ -141,6 +143,8 @@ export const getAuthStatus = async (providerId: string): Promise<AuthStatus> => 
 
 export const getProviderAuthHint = (providerId: string) => {
 	switch (providerId) {
+		case 'atlascloud':
+			return 'Set ATLASCLOUD_API_KEY or run "btca connect -p atlascloud".';
 		case 'github-copilot':
 			return 'Run "btca connect -p github-copilot" and complete device flow OAuth.';
 		case 'openai':

--- a/apps/server/src/providers/registry.ts
+++ b/apps/server/src/providers/registry.ts
@@ -5,6 +5,7 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 
+import { createAtlasCloud } from './atlascloud.ts';
 import { createCopilotProvider } from './copilot.ts';
 import { createOpenCodeZen } from './opencode.ts';
 import { createOpenAICodex } from './openai.ts';
@@ -31,6 +32,9 @@ export type ProviderFactory = (options?: any) => {
 
 // Registry of all supported providers
 export const PROVIDER_REGISTRY: Record<string, ProviderFactory> = {
+	// Atlas Cloud (OpenAI-compatible gateway)
+	atlascloud: createAtlasCloud as ProviderFactory,
+
 	// OpenCode Zen (curated models gateway)
 	opencode: createOpenCodeZen as ProviderFactory,
 


### PR DESCRIPTION
## Summary

- add a first-class `atlascloud` provider backed by the existing OpenAI-compatible AI SDK adapter
- use `ATLASCLOUD_API_KEY`, default to `https://api.atlascloud.ai/v1`, and allow endpoint overrides through `ATLASCLOUD_BASE_URL`
- expose Atlas Cloud in `btca connect` with a curated DeepSeek V4 Pro model and document the authentication flow

## Validation

- `bun run --cwd apps/server check`
- `bun run --cwd apps/cli check`
- `bun run --cwd apps/server test` (53 passed, 6 skipped)
- `bun test apps/cli/src` (50 passed)
- Prettier check for all changed files
- real AI SDK request through the new provider returned `ATLAS_OK` with `deepseek-ai/deepseek-v4-pro`

No dependencies or lockfiles changed. I did not run a build because the repository AGENTS.md explicitly prohibits dev/build commands. `bun run --cwd apps/docs check` could not start because the external `mint` executable is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider integration mirroring existing OpenRouter/openai-compat patterns; no changes to core request handling or shared auth beyond a new provider ID.
> 
> **Overview**
> Adds **Atlas Cloud** as a first-class AI provider so users can route requests through Atlas’s OpenAI-compatible API instead of only generic `openai-compat` setup.
> 
> On the server, a new `createAtlasCloud` factory registers in the provider registry and uses `@ai-sdk/openai-compatible` with default base URL `https://api.atlascloud.ai/v1`. Credentials resolve from OpenCode `auth.json` or **`ATLASCLOUD_API_KEY`**, with optional **`ATLASCLOUD_BASE_URL`** for endpoint overrides. Auth status and setup hints follow the same API-key pattern as OpenRouter and MiniMax.
> 
> The CLI **`btca connect`** flow treats `atlascloud` like other API-key providers (prompt, save key, setup link to the Atlas console). Connect metadata adds label, curated default model **`deepseek-ai/deepseek-v4-pro`**, model catalog URL, and auth guidance. Docs (`btca.spec.md`, authentication guide) list the provider and env vars.
> 
> Tests cover registry registration, model binding, and env-based auth for the new provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa874c4cd2bcdd39ad6bc108d97ed3eb9d7f84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Atlas Cloud as an OpenAI-compatible provider
> - Adds a new `atlascloud` provider backed by [`atlascloud.ts`](https://github.com/davis7dotsh/better-context/pull/229/files#diff-da0312bb0f0a52e982015aa636138f34ab527703dc4c9b0a6a0c1735cb924042), using `createOpenAICompatible` with credentials from `ATLASCLOUD_API_KEY` and base URL from `ATLASCLOUD_BASE_URL` (default: `https://api.atlascloud.ai/v1`).
> - Registers `atlascloud` in the provider registry, auth system, and CLI connect flow alongside existing API-key providers.
> - Adds `deepseek-ai/deepseek-v4-pro` as the curated model and includes setup links and auth guidance in the CLI constants.
> - Updates docs to list `ATLASCLOUD_API_KEY` and `ATLASCLOUD_BASE_URL` as supported environment variables.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fa874c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Atlas Cloud as an API-key-authenticated OpenAI-compatible provider, including provider registration, CLI connection guidance, environment overrides, and a curated DeepSeek V4 Pro model.

The Atlas Cloud inference endpoint concern was disproved by a live credential-free check: `GET https://api.atlascloud.ai/v1/models` returned the configured model, and a standard request to `/v1/chat/completions` reached the expected authentication check. The separate `/api/v1/models` catalog endpoint does not replace `/v1` as the inference endpoint.

No defects were found. Safe to merge.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed that GET https://api.atlascloud.ai/v1/models returns 125 inference models and exact\_configured\_model\_present: True, while POST https://api.atlascloud.ai/v1/chat/completions without credentials returns 401 with an invalid token.
- Inspected the relevant code paths and confirmed the base URL is declared in apps/server/src/providers/atlascloud.ts and is passed into createOpenAICompatible to form the chat model.
- Reviewed the credential-free live endpoint probe source script atlascloud-contract-check.sh to understand how the probe is performed against the Atlas Cloud endpoints.
- Examined the Atlas Cloud endpoint contract probe output artifact to verify that the probe executed and recorded endpoint interactions as intended.
- Reviewed the PR Atlas Cloud provider and configured model lines to confirm the base URL and model configuration are established in the PR.

<a href="https://app.greptile.com/trex/runs/16997287/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Atlas Cloud provider"](https://github.com/davis7dotsh/better-context/commit/1fa874c4cd2bcdd39ad6bc108d97ed3eb9d7f84f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49544625)</sub>

<!-- /greptile_comment -->